### PR TITLE
introduce dedicated property connected to guard dbconnect and dbclose methods

### DIFF
--- a/src/Driver/MysqliDriver.php
+++ b/src/Driver/MysqliDriver.php
@@ -31,6 +31,8 @@ use mysqli;
  */
 class MysqliDriver extends DriverAbstract
 {
+    private $connected = false;
+
     /**  @var mysqli */
     private $linkDB; //DB-Link
 
@@ -51,6 +53,10 @@ class MysqliDriver extends DriverAbstract
      */
     public function dbconnect(ConnectionParameters $objParams)
     {
+        if ($this->connected) {
+            return true;
+        }
+
         $port = $objParams->getPort();
         if (empty($port)) {
             $port = 3306;
@@ -79,6 +85,7 @@ class MysqliDriver extends DriverAbstract
         $this->_pQuery("SET character_set_database ='utf8'", array());
         $this->_pQuery("SET character_set_server ='utf8'", array());
 
+        $this->connected = true;
         return true;
     }
 
@@ -87,10 +94,13 @@ class MysqliDriver extends DriverAbstract
      */
     public function dbclose()
     {
-        if ($this->linkDB !== null) {
-            $this->linkDB->close();
-            $this->linkDB = null;
+        if (!$this->connected) {
+            return;
         }
+
+        $this->linkDB->close();
+        $this->linkDB = null;
+        $this->connected = false;
     }
 
     /**


### PR DESCRIPTION
As connection state management using the concrete MySQLi instance in the `linkDB` property does not seem to prevent duplicate `close` invocations, I propose a dedicated property to carry the connection state.