### PR TITLE
Update prettifyQuery to work with integer params

### DIFF
--- a/src/Connection.php
+++ b/src/Connection.php
@@ -1181,6 +1181,9 @@ class Connection implements ConnectionInterface
             if ($strOneParam === null) {
                 $strOneParam = 'null';
             }
+            if (is_int($strOneParam)) {
+                $strOneParam = (string) $strOneParam;
+            }
 
             $intPos = strpos($strQuery, '?');
             if ($intPos !== false) {


### PR DESCRIPTION
cast int to string - since having integer params leads to "substr_replace(): Argument #2 ($replace) must be of type array|string, int given" error

closes #38 