### PR TITLE
fix(): postgres driver casts columns to string ahead of applying subs…

### DIFF
--- a/src/Driver/PostgresDriver.php
+++ b/src/Driver/PostgresDriver.php
@@ -555,6 +555,17 @@ class PostgresDriver extends DriverAbstract
         return $strQuery." LIMIT  ".$intEnd." OFFSET ".$intStart;
     }
 
+    public function getSubstringExpression(string $value, int $offset, ?int $length): string
+    {
+        $parameters = ['cast (' . $value . ' as text)' , $offset];
+        if (isset($length)) {
+            $parameters[] = $length;
+        }
+
+        return 'SUBSTRING(' . implode(', ', $parameters) . ')';
+    }
+
+
     /**
      * @inheritDoc
      */


### PR DESCRIPTION
…tr()