### PR TITLE
Feat/upgrade symfony process and code styling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,14 @@
 
 ## 3.0.0
 
-- Bump `symfony/process` to `^6.0.0`.
-- Clean up code
+- Bumps `symfony/process` to `^6.0.0`.
+- Renames `ConnectionInterface::transactionBegin()` to `ConnectionInterface::beginTransaction()`.
+- Renames `ConnectionInterface::transactionCommit()` to `ConnectionInterface::commitTransaction()`.
+- Renames `ConnectionInterface::transactionRollback()` to `ConnectionInterface::rollbackTransaction()`.
+- Renames `DriverInterface::transactionBegin()` to `DriverInterface::beginTransaction()`.
+- Renames `DriverInterface::transactionCommit()` to `DriverInterface::commitTransaction()`.
+- Renames `DriverInterface::transactionRollback()` to `DriverInterface::rollbackTransaction()`.
+- Cleans up code
 
 ## 2.0.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 3.0.0
+
+- Bump `symfony/process` to `^6.0.0`.
+- Clean up code
+
 ## 2.0.2
 
 * Add missing lazy connect

--- a/bc_layer.php
+++ b/bc_layer.php
@@ -1,8 +1,0 @@
-<?php
-
-class_alias(\Artemeon\Database\Schema\DataType::class, 'Kajona\System\System\DbDatatypes');
-class_alias(\Artemeon\Database\Schema\Table::class, 'Kajona\System\System\Db\Schema\Table');
-class_alias(\Artemeon\Database\Schema\TableColumn::class, 'Kajona\System\System\Db\Schema\TableColumn');
-class_alias(\Artemeon\Database\Schema\TableIndex::class, 'Kajona\System\System\Db\Schema\TableIndex');
-class_alias(\Artemeon\Database\Schema\TableKey::class, 'Kajona\System\System\Db\Schema\TableKey');
-class_alias(\Artemeon\Database\ConnectionParameters::class, 'Kajona\System\System\DbConnectionParams');

--- a/composer.json
+++ b/composer.json
@@ -1,33 +1,32 @@
 {
   "name": "artemeon/database",
+  "description": "",
   "license": "MIT",
   "type": "library",
-  "description": "",
   "authors": [
     {
       "name": "ARTEMEON Management Partner GmbH",
       "email": "development@artemeon.de"
     }
   ],
-  "autoload": {
-    "psr-4": {
-      "Artemeon\\Database\\": "src/"
-    },
-    "files": ["bc_layer.php"]
-  },
-  "autoload-dev": {
-    "psr-4": {
-      "Artemeon\\Database\\Tests\\": "tests/"
-    }
-  },
   "require": {
-    "php": ">=8.0",
+    "php": "^8.2",
     "psr/log": "^1.1",
-    "symfony/process": "^5.0",
+    "symfony/process": "^6.0.0",
     "symfony/polyfill-mbstring": "^1.15"
   },
   "require-dev": {
     "phpunit/phpunit": "^8.0",
     "vimeo/psalm": "^3.16"
+  },
+  "autoload": {
+    "psr-4": {
+      "Artemeon\\Database\\": "src/"
+    }
+  },
+  "autoload-dev": {
+    "psr-4": {
+      "Artemeon\\Database\\Tests\\": "tests/"
+    }
   }
 }

--- a/src/Connection.php
+++ b/src/Connection.php
@@ -21,92 +21,79 @@ use Artemeon\Database\Exception\DriverNotFoundException;
 use Artemeon\Database\Exception\QueryException;
 use Artemeon\Database\Exception\RemoveColumnException;
 use Artemeon\Database\Exception\TableNotFoundException;
+use Artemeon\Database\Schema\DataType;
 use Artemeon\Database\Schema\Table;
 use Artemeon\Database\Schema\TableIndex;
+use Generator;
+use InvalidArgumentException;
 use Psr\Log\LoggerInterface;
 
 /**
  * This class handles all traffic from and to the database and takes care of a correct tx-handling
  * CHANGE WITH CARE!
- * Since version 3.4, prepared statments are supported. As a parameter-escaping, only the ? char is allowed,
+ * Since version 3.4, prepared statements are supported. As a parameter-escaping, only the ? char is allowed,
  * named params are not supported at the moment.
  * Old plain queries are still allows, but will be discontinued around kajona 3.5 / 4.0. Up from kajona > 3.4.0
  * a warning will be generated when using the old apis.
  * When using prepared statements, all escaping is done by the database layer.
  * When using the old, plain queries, you have to escape all embedded arguments yourself by using dbsafeString()
- *
- * @package module_system
- * @author sidler@mulchprod.de
  */
 class Connection implements ConnectionInterface
 {
-    private $arrQueryCache = array(); //Array to cache queries
-    private $arrTablesCache = [];
-    private $intNumber = 0; //Number of queries send to database
-    private $intNumberCache = 0; //Number of queries returned from cache
-
     /**
-     * @var ConnectionParameters
+     * Array to cache queries.
      */
-    private $connectionParams;
+    private array $queryCache = [];
+
+    private array $tablesCache = [];
 
     /**
-     * @var DriverFactory
+     * Number of queries sent to the database.
      */
-    private $driverFactory;
+    private int $number = 0;
 
     /**
-     * @var LoggerInterface
+     * Number of queries returned from cache.
      */
-    private $logger;
+    private int $numberCache = 0;
+
+    private ConnectionParameters $connectionParams;
+
+    private DriverFactory $driverFactory;
+
+    private ?LoggerInterface $logger;
+
+    private ?int $debugLevel;
 
     /**
-     * @var int
+     * Instance of the db-driver defined in the configs.
      */
-    private $debugLevel;
+    protected ?DriverInterface $dbDriver = null;
 
     /**
-     * Instance of the db-driver defined in the configs
-     *
-     * @var DriverInterface
+     * The number of transactions currently opened.
      */
-    protected $objDbDriver = null; //An object of the db-driver defined in the configs
+    private int $numberOfOpenTransactions = 0;
 
     /**
-     * The number of transactions currently opened
-     *
-     * @var int
+     * Set to true, if a rollback is requested, but there are still open transaction.
+     * In this case, the tx is rolled back, when the enclosing tx is finished.
      */
-    private $intNumberOfOpenTransactions = 0; //The number of transactions opened
+    private bool $currentTransactionIsDirty = false;
 
     /**
-     * Set to true, if a rollback is requested, but there are still open tx.
-     * In this case, the tx is rolled back, when the enclosing tx is finished
-     *
-     * @var bool
-     */
-    private $bitCurrentTxIsDirty = false;
-
-    /**
-     * Flag indicating if the internal connection was setup.
+     * Flag indicating if the internal connection was set up.
      * Needed to have a proper lazy-connection initialization.
-     *
-     * @var bool
      */
-    private $bitConnected = false;
+    private bool $connected = false;
 
     /**
-     * Enables or disables dbsafeString in total
-     * @var bool
+     * Enables or disables dbsafeString in total.
      * @internal
      */
-    public static $bitDbSafeStringEnabled = true;
+    public static bool $dbSafeStringEnabled = true;
 
     /**
-     * @param ConnectionParameters $connectionParams
-     * @param DriverFactory $driverFactory
-     * @param LoggerInterface|null $logger
-     * @param int|null $debugLevel
      * @throws Exception\DriverNotFoundException
      */
     public function __construct(
@@ -119,81 +106,78 @@ class Connection implements ConnectionInterface
         $this->driverFactory = $driverFactory;
         $this->logger = $logger;
         $this->debugLevel = $debugLevel;
-        $this->objDbDriver = $this->driverFactory->factory($this->connectionParams->getDriver());
+        $this->dbDriver = $this->driverFactory->factory($this->connectionParams->getDriver());
     }
 
     /**
      * Destructor.
-     * Handles the closing of remaining tx and closes the db-connection
+     * Handles the closing of remaining transactions and closes the DB connection.
      */
-    public function close()
+    public function close(): void
     {
-        if ($this->intNumberOfOpenTransactions != 0) {
-            //something bad happened. rollback, plz
-            $this->objDbDriver->transactionRollback();
-            if ($this->logger !== null) {
-                $this->logger->warning("Rolled back open transactions on deletion of current instance of Db!");
-            }
+        if ($this->numberOfOpenTransactions !== 0) {
+            $this->dbDriver->rollbackTransaction();
+            $this->logger?->warning('Rolled back open transactions on deletion of current instance of Db!');
         }
 
+        if ($this->dbDriver !== null && $this->connected) {
+            $this->logger?->info('closing database-connection');
 
-        if ($this->objDbDriver !== null && $this->bitConnected) {
-            if ($this->logger !== null) {
-                $this->logger->info("closing database-connection");
-            }
-
-            $this->objDbDriver->dbclose();
+            $this->dbDriver->dbclose();
         }
     }
 
     /**
-     * This method connects with the database
+     * This method connects with the database.
      *
-     * @return void
      * @throws ConnectionException
      */
-    protected function dbconnect()
+    protected function dbconnect(): void
     {
-        $this->bitConnected = $this->objDbDriver->dbconnect($this->connectionParams);
+        $this->connected = $this->dbDriver->dbconnect($this->connectionParams);
     }
 
     /**
      * @inheritDoc
+     * @throws ConnectionException
      */
-    public function multiInsert(string $strTable, array $arrColumns, array $arrValueSets, ?array $arrEscapes = null)
+    public function multiInsert(string $tableName, array $columns, array $valueSets, ?array $escapes = null): bool
     {
-        if (!$this->bitConnected) {
+        if (!$this->connected) {
             $this->dbconnect();
         }
 
-        if (count($arrValueSets) == 0) {
+        if (count($valueSets) === 0) {
             return true;
         }
 
-        //chunk columns down to less then 1000 params, could lead to errors on oracle and sqlite otherwise
-        $bitReturn = true;
-        $intSetsPerInsert = (int)floor(970 / count($arrColumns));
+        // chunk columns down to less than 1000 params, could lead to errors on Oracle and sqlite otherwise.
+        $output = true;
+        $setsPerInsert = (int) floor(970 / count($columns));
 
-        foreach (array_chunk($arrValueSets, $intSetsPerInsert) as $arrSingleValueSet) {
-            $bitReturn = $bitReturn && $this->objDbDriver->triggerMultiInsert(
-                    $strTable,
-                    $arrColumns,
-                    $arrSingleValueSet,
+        foreach (array_chunk($valueSets, $setsPerInsert) as $valueSet) {
+            $output = $output && $this->dbDriver->triggerMultiInsert(
+                    $tableName,
+                    $columns,
+                    $valueSet,
                     $this,
-                    $arrEscapes
+                    $escapes
                 );
         }
 
-        return $bitReturn;
+        return $output;
     }
 
     /**
      * @inheritDoc
+     * @throws ConnectionException
+     * @throws QueryException
      */
     public function insert(string $tableName, array $values, ?array $escapes = null): int
     {
         $this->multiInsert($tableName, array_keys($values), [array_values($values)], $escapes);
-        return $this->getIntAffectedRows();
+
+        return $this->getAffectedRowsCount();
     }
 
     /**
@@ -204,32 +188,32 @@ class Connection implements ConnectionInterface
         array $columns,
         array $identifiers,
         bool $cached = true,
-        ?array $escapes = []
+        ?array $escapes = [],
     ): ?array {
-        $query = \sprintf(
+        $query = sprintf(
             'SELECT %s FROM %s WHERE %s',
-            \implode(
+            implode(
                 ', ',
-                \array_map(
+                array_map(
                     function ($columnName): string {
                         return $this->encloseColumnName((string)$columnName);
                     },
-                    $columns
-                )
+                    $columns,
+                ),
             ),
             $this->encloseTableName($tableName),
-            \implode(
+            implode(
                 ' AND ',
-                \array_map(
+                array_map(
                     function (string $columnName): string {
                         return $this->encloseColumnName($columnName) . ' = ?';
                     },
-                    \array_keys($identifiers)
-                )
-            )
+                    array_keys($identifiers),
+                ),
+            ),
         );
 
-        $row = $this->getPRow($query, \array_values($identifiers), 0, $cached, $escapes);
+        $row = $this->getPRow($query, array_values($identifiers), 0, $cached, $escapes);
         if ($row === []) {
             return null;
         }
@@ -239,11 +223,12 @@ class Connection implements ConnectionInterface
 
     /**
      * @inheritDoc
+     * @throws QueryException
      */
     public function update(string $tableName, array $values, array $identifier, ?array $escapes = null): int
     {
         if (empty($identifier)) {
-            throw new \InvalidArgumentException('Empty identifier for update statement');
+            throw new InvalidArgumentException('Empty identifier for update statement');
         }
 
         $columns = [];
@@ -262,16 +247,18 @@ class Connection implements ConnectionInterface
         $query = 'UPDATE ' . $tableName . ' SET ' . implode(', ', $columns) . ' WHERE ' . implode(' AND ', $condition);
 
         $this->_pQuery($query, $params, $escapes ?? []);
-        return $this->getIntAffectedRows();
+
+        return $this->getAffectedRowsCount();
     }
 
     /**
      * @inheritDoc
+     * @throws QueryException
      */
     public function delete(string $tableName, array $identifier): int
     {
         if (empty($identifier)) {
-            throw new \InvalidArgumentException('Empty identifier for delete statement');
+            throw new InvalidArgumentException('Empty identifier for delete statement');
         }
 
         $condition = [];
@@ -284,84 +271,91 @@ class Connection implements ConnectionInterface
         $query = 'DELETE FROM ' . $tableName . ' WHERE ' . implode(' AND ', $condition);
 
         $this->_pQuery($query, $params);
-        return $this->getIntAffectedRows();
+
+        return $this->getAffectedRowsCount();
     }
 
     /**
      * @inheritDoc
+     * @throws ConnectionException
      */
-    public function insertOrUpdate($strTable, $arrColumns, $arrValues, $arrPrimaryColumns)
+    public function insertOrUpdate(string $tableName, array $columns, array $values, array $primaryColumns): bool
     {
-        if (!$this->bitConnected) {
+        if (!$this->connected) {
             $this->dbconnect();
         }
 
-        $bitReturn = $this->objDbDriver->insertOrUpdate($strTable, $arrColumns, $arrValues, $arrPrimaryColumns);
-        if (!$bitReturn) {
-            $this->getError("", array());
+        $output = $this->dbDriver->insertOrUpdate($tableName, $columns, $values, $primaryColumns);
+        if (!$output) {
+            $this->getError('', []);
         }
 
-        return $bitReturn;
+        return $output;
     }
 
     /**
      * @inheritDoc
+     * @throws ConnectionException
      */
-    public function _pQuery($strQuery, $arrParams = [], array $arrEscapes = [])
+    public function _pQuery(string $query, array $params = [], array $escapes = []): bool
     {
-        if (!$this->bitConnected) {
+        if (!$this->connected) {
             $this->dbconnect();
         }
 
-        $bitReturn = false;
+        $output = false;
 
-        $strQuery = $this->processQuery($strQuery);
+        $query = $this->processQuery($query);
 
-        //Increasing the counter
-        $this->intNumber++;
+        // Increasing the counter
+        $this->number++;
 
-        if ($this->objDbDriver != null) {
-            $bitReturn = $this->objDbDriver->_pQuery($strQuery, $this->dbsafeParams($arrParams, $arrEscapes));
+        if ($this->dbDriver !== null) {
+            $output = $this->dbDriver->_pQuery($query, $this->dbsafeParams($params, $escapes));
         }
 
-        if (!$bitReturn) {
-            $this->getError($strQuery, $arrParams);
+        if (!$output) {
+            $this->getError($query, $params);
         }
 
-        return $bitReturn;
+        return $output;
     }
 
     /**
      * @inheritDoc
+     * @throws ConnectionException
+     * @throws QueryException
      */
     public function executeStatement(string $query, array $params = []): int
     {
         $this->_pQuery($query, $params);
-        return $this->objDbDriver->getIntAffectedRows();
+
+        return $this->dbDriver->getAffectedRowsCount();
     }
 
     /**
      * @inheritDoc
      */
-    public function getIntAffectedRows()
+    public function getAffectedRowsCount(): int
     {
-        return $this->objDbDriver->getIntAffectedRows();
+        return $this->dbDriver->getAffectedRowsCount();
     }
 
     /**
      * @inheritDoc
+     * @throws ConnectionException
      */
-    public function getPRow($strQuery, $arrParams = [], $intNr = 0, $bitCache = true, array $arrEscapes = [])
+    public function getPRow(string $query, array $params = [], int $number = 0, bool $cache = true, array $escapes = []): array
     {
-        if (!$this->bitConnected) {
+        if (!$this->connected) {
             $this->dbconnect();
         }
 
-        if ($intNr !== 0) {
-            trigger_error("The intNr parameter is deprecated", E_USER_DEPRECATED);
+        if ($number !== 0) {
+            trigger_error('The number parameter is deprecated', E_USER_DEPRECATED);
         }
 
-        $result = $this->objDbDriver->getPArray($strQuery, $arrParams);
+        $result = $this->dbDriver->getPArray($query, $params);
         foreach ($result as $row) {
             return $row;
         }
@@ -371,67 +365,68 @@ class Connection implements ConnectionInterface
 
     /**
      * @inheritDoc
+     * @throws ConnectionException
      */
     public function getPArray(
-        $strQuery,
-        $arrParams = [],
-        $intStart = null,
-        $intEnd = null,
-        $bitCache = true,
-        array $arrEscapes = []
-    ) {
-        if (!$this->bitConnected) {
+        string $query,
+        array $params = [],
+        ?int $start = null,
+        ?int $end = null,
+        bool $cache = true,
+        array $escapes = [],
+    ): array {
+        if (!$this->connected) {
             $this->dbconnect();
         }
 
-        //param validation
-        if ((int)$intStart < 0) {
-            $intStart = null;
+        // param validation
+        if ((int) $start < 0) {
+            $start = null;
         }
 
-        if ((int)$intEnd < 0) {
-            $intEnd = null;
+        if ((int) $end < 0) {
+            $end = null;
         }
 
+        $query = $this->processQuery($query);
+        // Increasing global counter
+        $this->number++;
 
-        $strQuery = $this->processQuery($strQuery);
-        //Increasing global counter
-        $this->intNumber++;
+        $queryMd5 = null;
+        if ($cache) {
+            $queryMd5 = md5($query . implode(',', $params) . $start . $end);
+            if (isset($this->queryCache[$queryMd5])) {
+                // Increasing Cache counter
+                $this->numberCache++;
 
-        $strQueryMd5 = null;
-        if ($bitCache) {
-            $strQueryMd5 = md5($strQuery . implode(",", $arrParams) . $intStart . $intEnd);
-            if (isset($this->arrQueryCache[$strQueryMd5])) {
-                //Increasing Cache counter
-                $this->intNumberCache++;
-                return $this->arrQueryCache[$strQueryMd5];
+                return $this->queryCache[$queryMd5];
             }
         }
 
-        if ($intStart !== null && $intEnd !== null && $intStart !== false && $intEnd !== false) {
-            $strQuery = $this->appendLimitExpression($strQuery, $intStart, $intEnd);
-            $arrReturn = $this->fetchAllAssociative($strQuery, $this->dbsafeParams($arrParams, $arrEscapes));
-        } else {
-            $arrReturn = $this->fetchAllAssociative($strQuery, $this->dbsafeParams($arrParams, $arrEscapes));
+        if ($start !== null && $end !== null) {
+            $query = $this->appendLimitExpression($query, $start, $end);
         }
 
-        if ($bitCache) {
-            $this->arrQueryCache[$strQueryMd5] = $arrReturn;
+        $output = $this->fetchAllAssociative($query, $this->dbsafeParams($params, $escapes));
+
+        if ($cache) {
+            $this->queryCache[$queryMd5] = $output;
         }
 
-        return $arrReturn;
+        return $output;
     }
 
     /**
      * @inheritDoc
+     * @throws ConnectionException
      */
-    public function getGenerator($query, array $params = [], $chunkSize = 2048, $paging = true)
+    public function getGenerator(string $query, array $params = [], int $chunkSize = 2048, bool $paging = true): Generator
     {
-        if (!$this->bitConnected) {
+        if (!$this->connected) {
             $this->dbconnect();
         }
 
-        $result = $this->objDbDriver->getPArray($query, $this->dbsafeParams($params, []));
+        $result = $this->dbDriver->getPArray($query, $this->dbsafeParams($params));
         $chunk = [];
 
         foreach ($result as $row) {
@@ -451,26 +446,30 @@ class Connection implements ConnectionInterface
 
     /**
      * @inheritDoc
+     * @throws ConnectionException
+     * @throws QueryException
      */
     public function fetchAllAssociative(string $query, array $params = []): array
     {
-        if (!$this->bitConnected) {
+        if (!$this->connected) {
             $this->dbconnect();
         }
 
-        return iterator_to_array($this->objDbDriver->getPArray($query, $params), false);
+        return iterator_to_array($this->dbDriver->getPArray($query, $params), false);
     }
 
     /**
      * @inheritDoc
+     * @throws ConnectionException
+     * @throws QueryException
      */
-    public function fetchAssociative(string $query, array $params = []): array|false
+    public function fetchAssociative(string $query, array $params = []): array | false
     {
-        if (!$this->bitConnected) {
+        if (!$this->connected) {
             $this->dbconnect();
         }
 
-        $result = $this->objDbDriver->getPArray($query, $params);
+        $result = $this->dbDriver->getPArray($query, $params);
         foreach ($result as $row) {
             return $row;
         }
@@ -480,15 +479,17 @@ class Connection implements ConnectionInterface
 
     /**
      * @inheritDoc
+     * @throws ConnectionException
+     * @throws QueryException
      */
     public function fetchFirstColumn(string $query, array $params = []): array
     {
-        if (!$this->bitConnected) {
+        if (!$this->connected) {
             $this->dbconnect();
         }
 
         $values = [];
-        $result = $this->objDbDriver->getPArray($query, $this->dbsafeParams($params, []));
+        $result = $this->dbDriver->getPArray($query, $this->dbsafeParams($params, []));
         foreach ($result as $row) {
             $values[] = reset($row);
         }
@@ -498,10 +499,12 @@ class Connection implements ConnectionInterface
 
     /**
      * @inheritDoc
+     * @throws ConnectionException
+     * @throws QueryException
      */
     public function fetchOne(string $query, array $params = []): mixed
     {
-        if (!$this->bitConnected) {
+        if (!$this->connected) {
             $this->dbconnect();
         }
 
@@ -515,160 +518,163 @@ class Connection implements ConnectionInterface
 
     /**
      * @inheritDoc
+     * @throws ConnectionException
+     * @throws QueryException
      */
-    public function iterateAssociative(string $query, array $params = []): \Generator
+    public function iterateAssociative(string $query, array $params = []): Generator
     {
-        if (!$this->bitConnected) {
+        if (!$this->connected) {
             $this->dbconnect();
         }
 
-        yield from $this->objDbDriver->getPArray($query, $this->dbsafeParams($params, []));
+        yield from $this->dbDriver->getPArray($query, $this->dbsafeParams($params));
     }
 
     /**
      * @inheritDoc
+     * @throws ConnectionException
+     * @throws QueryException
      */
-    public function iterateColumn(string $query, array $params = []): \Generator
+    public function iterateColumn(string $query, array $params = []): Generator
     {
-        if (!$this->bitConnected) {
+        if (!$this->connected) {
             $this->dbconnect();
         }
 
-        $result = $this->objDbDriver->getPArray($query, $this->dbsafeParams($params, []));
+        $result = $this->dbDriver->getPArray($query, $this->dbsafeParams($params));
         foreach ($result as $row) {
             yield reset($row);
         }
     }
 
     /**
-     * Writes the last DB-Error to the screen
+     * Writes the last DB-Error to the screen.
      *
-     * @param string $strQuery
-     * @return void
      * @throws QueryException
+     * @throws ConnectionException
      */
-    private function getError($strQuery, $arrParams)
+    private function getError(string $query, array $params): void
     {
-        if (!$this->bitConnected) {
+        if (!$this->connected) {
             $this->dbconnect();
         }
 
-        $strError = "";
-        if ($this->objDbDriver != null) {
-            $strError = $this->objDbDriver->getError();
+        $error = '';
+        if ($this->dbDriver !== null) {
+            $error = $this->dbDriver->getError();
         }
 
-        //reprocess query
-        $strQuery = str_ireplace(
-            array(" from ", " where ", " and ", " group by ", " order by "),
-            array("\nFROM ", "\nWHERE ", "\n\tAND ", "\nGROUP BY ", "\nORDER BY "),
-            $strQuery
+        // reprocess query
+        $query = str_ireplace(
+            [' from ', ' where ', ' and ', ' group by ', ' order by '],
+            ["\nFROM ", "\nWHERE ", "\n\tAND ", "\nGROUP BY ", "\nORDER BY "],
+            $query,
         );
 
-        $strQuery = $this->prettifyQuery($strQuery, $arrParams);
+        $query = $this->prettifyQuery($query, $params);
 
-        $strErrorCode = "";
-        $strErrorCode .= "Error in query\n\n";
+        $strErrorCode = "Error in query\n\n";
         $strErrorCode .= "Error:\n";
-        $strErrorCode .= $strError . "\n\n";
+        $strErrorCode .= $error . "\n\n";
         $strErrorCode .= "Query:\n";
-        $strErrorCode .= $strQuery . "\n";
+        $strErrorCode .= $query . "\n";
         $strErrorCode .= "\n\n";
-        $strErrorCode .= "Params: " . implode(", ", $arrParams) . "\n";
+        $strErrorCode .= 'Params: ' . implode(', ', $params) . "\n";
         $strErrorCode .= "Callstack:\n";
-        if (function_exists("debug_backtrace")) {
+        if (function_exists('debug_backtrace')) {
             $arrStack = debug_backtrace();
 
-            foreach ($arrStack as $intPos => $arrValue) {
-                $strErrorCode .= (isset($arrValue["file"]) ? $arrValue["file"] : "n.a.") . "\n\t Row " . (isset($arrValue["line"]) ? $arrValue["line"] : "n.a.") . ", function " . $arrStack[$intPos]["function"] . "\n";
+            foreach ($arrStack as $arrValue) {
+                $strErrorCode .= ($arrValue['file'] ?? 'n.a.') . "\n\t Row " . ($arrValue['line'] ?? 'n.a.') . ', function ' . $arrValue['function'] . "\n";
             }
         }
 
-        //send a warning to the logger
-        if ($this->logger !== null) {
-            $this->logger->error($strErrorCode);
-        }
+        // send a warning to the logger
+        $this->logger?->error($strErrorCode);
 
-        throw new QueryException($strError, $strQuery, $arrParams);
+        throw new QueryException($error, $query, $params);
     }
 
     /**
      * @inheritDoc
+     * @throws ConnectionException
      */
-    public function transactionBegin()
+    public function beginTransaction(): void
     {
-        if (!$this->bitConnected) {
+        if (!$this->connected) {
             $this->dbconnect();
         }
 
-        if ($this->objDbDriver != null) {
-            //just start a new tx, if no other tx is open
-            if ($this->intNumberOfOpenTransactions == 0) {
-                $this->objDbDriver->transactionBegin();
-            }
-
-            //increase tx-counter
-            $this->intNumberOfOpenTransactions++;
+        if ($this->dbDriver === null) {
+            return;
         }
+
+        // just start a new transaction, if no other transaction is open.
+        if ($this->numberOfOpenTransactions === 0) {
+            $this->dbDriver->beginTransaction();
+        }
+
+        // increase transaction-counter
+        $this->numberOfOpenTransactions++;
     }
 
     /**
      * @inheritDoc
+     * @throws ConnectionException
+     * @throws CommitException
      */
-    public function transactionCommit()
+    public function commitTransaction(): void
     {
-        if (!$this->bitConnected) {
+        if (!$this->connected) {
             $this->dbconnect();
         }
 
-        if ($this->objDbDriver != null) {
-            //check, if the current tx is allowed to be commited
-            if ($this->intNumberOfOpenTransactions == 1) {
-                //decrement counter
-                $this->intNumberOfOpenTransactions--;
+        if ($this->dbDriver === null) {
+            return;
+        }
 
-                //so, this is the last remaining tx. Commit or rollback?
-                if (!$this->bitCurrentTxIsDirty) {
-                    $this->objDbDriver->transactionCommit();
-                } else {
-                    $this->objDbDriver->transactionRollback();
-                    $this->bitCurrentTxIsDirty = false;
-                    throw new CommitException('Could not commit transaction because a rollback occurred inside a nested transaction, because of this we have have executed a rollback on the complete outer transaction which may result in data loss');
-                }
+        // check, if the current tx is allowed to be committed.
+        if ($this->numberOfOpenTransactions === 1) {
+            $this->numberOfOpenTransactions--;
+
+            if (!$this->currentTransactionIsDirty) {
+                $this->dbDriver->commitTransaction();
             } else {
-                $this->intNumberOfOpenTransactions--;
+                $this->dbDriver->rollbackTransaction();
+                $this->currentTransactionIsDirty = false;
+                throw new CommitException('Could not commit transaction because a rollback occurred inside a nested transaction, because of this we have have executed a rollback on the complete outer transaction which may result in data loss');
             }
+        } else {
+            $this->numberOfOpenTransactions--;
         }
     }
 
     /**
      * @inheritDoc
+     * @throws ConnectionException
      */
-    public function transactionRollback()
+    public function rollbackTransaction(): void
     {
-        if (!$this->bitConnected) {
+        if (!$this->connected) {
             $this->dbconnect();
         }
 
-        if ($this->objDbDriver != null) {
-            if ($this->intNumberOfOpenTransactions == 1) {
-                //so, this is the last remaining tx. rollback anyway
-                $this->objDbDriver->transactionRollback();
-                $this->bitCurrentTxIsDirty = false;
-                //decrement counter
-                $this->intNumberOfOpenTransactions--;
-            } else {
-                //mark the current tx session a dirty
-                $this->bitCurrentTxIsDirty = true;
-                //decrement the number of open tx
-                $this->intNumberOfOpenTransactions--;
-            }
+        if ($this->dbDriver === null) {
+            return;
         }
+
+        if ($this->numberOfOpenTransactions === 1) {
+            $this->dbDriver->rollbackTransaction();
+            $this->currentTransactionIsDirty = false;
+        } else {
+            $this->currentTransactionIsDirty = true;
+        }
+        $this->numberOfOpenTransactions--;
     }
 
     public function hasOpenTransactions(): bool
     {
-        return $this->intNumberOfOpenTransactions > 0;
+        return $this->numberOfOpenTransactions > 0;
     }
 
     /**
@@ -676,41 +682,42 @@ class Connection implements ConnectionInterface
      */
     public function hasDriver(string $class): bool
     {
-        return $this->objDbDriver instanceof $class;
+        return $this->dbDriver instanceof $class;
     }
 
     /**
      * @inheritDoc
+     * @throws ConnectionException
      */
-    public function getTables($prefix = null)
+    public function getTables(string $prefix = null): array
     {
         if ($prefix === null) {
-            $prefix = "agp_";
+            $prefix = 'agp_';
         }
 
-        if (!$this->bitConnected) {
+        if (!$this->connected) {
             $this->dbconnect();
         }
 
-        if (isset($this->arrTablesCache[$prefix])) {
-            return $this->arrTablesCache[$prefix];
+        if (isset($this->tablesCache[$prefix])) {
+            return $this->tablesCache[$prefix];
         }
 
-        $this->arrTablesCache[$prefix] = [];
+        $this->tablesCache[$prefix] = [];
 
-        if ($this->objDbDriver != null) {
+        if ($this->dbDriver !== null) {
             // increase global counter
-            $this->intNumber++;
-            $arrTemp = $this->objDbDriver->getTables();
+            $this->number++;
+            $tables = $this->dbDriver->getTables();
 
-            foreach ($arrTemp as $arrTable) {
-                if (substr($arrTable["name"], 0, strlen($prefix)) === $prefix) {
-                    $this->arrTablesCache[$prefix][] = $arrTable["name"];
+            foreach ($tables as $table) {
+                if (str_starts_with($table['name'], $prefix)) {
+                    $this->tablesCache[$prefix][] = $table['name'];
                 }
             }
         }
 
-        return $this->arrTablesCache[$prefix];
+        return $this->tablesCache[$prefix];
     }
 
     /**
@@ -718,28 +725,29 @@ class Connection implements ConnectionInterface
      * Should return an array for each row consisting of:
      * array ("columnName", "columnType")
      *
-     * @param string $strTableName
-     * @return array
+     * @throws QueryException
+     * @throws TableNotFoundException
+     * @throws ConnectionException
      * @deprecated
-     *
      */
-    public function getColumnsOfTable($strTableName)
+    public function getColumnsOfTable(string $tableName): array
     {
-        if (!$this->hasTable($strTableName)) {
-            throw new TableNotFoundException($strTableName);
+        if (!$this->hasTable($tableName)) {
+            throw new TableNotFoundException($tableName);
         }
 
-        if (!$this->bitConnected) {
+        if (!$this->connected) {
             $this->dbconnect();
         }
 
-        $table = $this->objDbDriver->getTableInformation($strTableName);
+        $table = $this->dbDriver->getTableInformation($tableName);
 
         $return = [];
         foreach ($table->getColumns() as $column) {
-            $return[$column->getName()] = [
-                "columnName" => $column->getName(),
-                "columnType" => $column->getInternalType()
+            $columnName = $column->getName();
+            $return[$columnName] = [
+                'columnName' => $columnName,
+                'columnType' => $column->getInternalType()
             ];
         }
 
@@ -748,72 +756,76 @@ class Connection implements ConnectionInterface
 
     /**
      * @inheritDoc
+     * @throws TableNotFoundException
+     * @throws ConnectionException
      */
-    public function getTableInformation($tableName): Table
+    public function getTableInformation(string $tableName): Table
     {
         if (!$this->hasTable($tableName)) {
             throw new TableNotFoundException($tableName);
         }
 
-        if (!$this->bitConnected) {
+        if (!$this->connected) {
             $this->dbconnect();
         }
 
-        return $this->objDbDriver->getTableInformation($tableName);
+        return $this->dbDriver->getTableInformation($tableName);
     }
 
     /**
      * @inheritDoc
      */
-    public function getDatatype($strType)
+    public function getDatatype(DataType $type): string
     {
-        return $this->objDbDriver->getDatatype($strType);
+        return $this->dbDriver->getDatatype($type);
     }
 
     /**
      * @inheritDoc
+     * @throws ConnectionException
      */
-    public function createTable($strName, $arrFields, $arrKeys, $arrIndices = array())
+    public function createTable(string $tableName, array $columns, array $keys, array $indices = []): bool
     {
-        if (!$this->bitConnected) {
+        if (!$this->connected) {
             $this->dbconnect();
         }
 
         // always lower case the table name
-        $strName = strtolower($strName);
+        $tableName = strtolower($tableName);
 
         // check whether table already exists
-        $arrTables = $this->objDbDriver->getTables();
-        foreach ($arrTables as $arrTable) {
-            if ($arrTable["name"] == $strName) {
+        $tables = $this->dbDriver->getTables();
+        foreach ($tables as $table) {
+            if ($table['name'] === $tableName) {
                 return true;
             }
         }
 
         // create table
-        $bitReturn = $this->objDbDriver->createTable($strName, $arrFields, $arrKeys);
-        if (!$bitReturn) {
-            $this->getError("", array());
+        $output = $this->dbDriver->createTable($tableName, $columns, $keys);
+        if (!$output) {
+            $this->getError('', []);
         }
 
         // create index
-        if ($bitReturn && count($arrIndices) > 0) {
-            foreach ($arrIndices as $strOneIndex) {
-                if (is_array($strOneIndex)) {
-                    $bitReturn = $bitReturn && $this->createIndex($strName, "ix_" . uniqid(), $strOneIndex);
+        if ($output && count($indices) > 0) {
+            foreach ($indices as $index) {
+                if (is_array($index)) {
+                    $output = $output && $this->createIndex($tableName, 'ix_' . uniqid(), $index);
                 } else {
-                    $bitReturn = $bitReturn && $this->createIndex($strName, "ix_" . uniqid(), [$strOneIndex]);
+                    $output = $output && $this->createIndex($tableName, 'ix_' . uniqid(), [$index]);
                 }
             }
         }
 
         $this->flushTablesCache();
 
-        return $bitReturn;
+        return $output;
     }
 
     /**
      * @inheritDoc
+     * @throws ConnectionException
      */
     public function dropTable(string $tableName): void
     {
@@ -828,6 +840,7 @@ class Connection implements ConnectionInterface
 
     /**
      * @inheritDoc
+     * @throws ConnectionException
      */
     public function generateTableFromMetadata(Table $table): void
     {
@@ -850,70 +863,75 @@ class Connection implements ConnectionInterface
 
     /**
      * @inheritDoc
+     * @throws ConnectionException
      */
-    public function createIndex($strTable, $strName, array $arrColumns, $bitUnique = false)
+    public function createIndex(string $tableName, string $name, array $columns, bool $unique = false): bool
     {
-        if (!$this->bitConnected) {
+        if (!$this->connected) {
             $this->dbconnect();
         }
 
-        if ($this->objDbDriver->hasIndex($strTable, $strName)) {
+        if ($this->dbDriver->hasIndex($tableName, $name)) {
             return true;
         }
-        $bitReturn = $this->objDbDriver->createIndex($strTable, $strName, $arrColumns, $bitUnique);
-        if (!$bitReturn) {
-            $this->getError("", array());
+        $output = $this->dbDriver->createIndex($tableName, $name, $columns, $unique);
+        if (!$output) {
+            $this->getError('', []);
         }
 
-        return $bitReturn;
+        return $output;
     }
 
     /**
      * @inheritDoc
+     * @throws ConnectionException
      */
     public function deleteIndex(string $table, string $index): bool
     {
-        if (!$this->bitConnected) {
+        if (!$this->connected) {
             $this->dbconnect();
         }
 
-        return $this->objDbDriver->deleteIndex($table, $index);
+        return $this->dbDriver->deleteIndex($table, $index);
     }
 
     /**
      * @inheritDoc
+     * @throws ConnectionException
      */
-    public function addIndex(string $table, TableIndex $index)
+    public function addIndex(string $table, TableIndex $index): bool
     {
-        if (!$this->bitConnected) {
+        if (!$this->connected) {
             $this->dbconnect();
         }
 
-        return $this->objDbDriver->addIndex($table, $index);
+        return $this->dbDriver->addIndex($table, $index);
     }
 
     /**
      * @inheritDoc
+     * @throws ConnectionException
      */
-    public function hasIndex($strTable, $strName): bool
+    public function hasIndex(string $tableName, string $name): bool
     {
-        if (!$this->bitConnected) {
+        if (!$this->connected) {
             $this->dbconnect();
         }
 
-        return $this->objDbDriver->hasIndex($strTable, $strName);
+        return $this->dbDriver->hasIndex($tableName, $name);
     }
 
     /**
      * @inheritDoc
+     * @throws ConnectionException
      */
-    public function renameTable($strOldName, $strNewName)
+    public function renameTable(string $oldName, string $newName): bool
     {
-        if (!$this->bitConnected) {
+        if (!$this->connected) {
             $this->dbconnect();
         }
 
-        $return = $this->objDbDriver->renameTable($strOldName, $strNewName);
+        $return = $this->dbDriver->renameTable($oldName, $newName);
 
         $this->flushTablesCache();
 
@@ -922,300 +940,275 @@ class Connection implements ConnectionInterface
 
     /**
      * @inheritDoc
+     * @throws ConnectionException
      */
-    public function changeColumn($strTable, $strOldColumnName, $strNewColumnName, $strNewDatatype)
+    public function changeColumn(string $tableName, string $oldColumnName, string $newColumnName, DataType $newDataType): bool
     {
-        if (!$this->bitConnected) {
+        if (!$this->connected) {
             $this->dbconnect();
         }
 
-        $return = $this->objDbDriver->changeColumn($strTable, $strOldColumnName, $strNewColumnName, $strNewDatatype);
+        $return = $this->dbDriver->changeColumn($tableName, $oldColumnName, $newColumnName, $newDataType);
 
         if (!$return) {
-            $error = $this->objDbDriver->getError();
+            $error = $this->dbDriver->getError();
             throw new ChangeColumnException(
                 'Could not change column: ' . $error,
-                $strTable,
-                $strOldColumnName,
-                $strNewColumnName,
-                $strNewDatatype
+                $tableName,
+                $oldColumnName,
+                $newColumnName,
+                $newDataType,
             );
         }
 
         $this->flushTablesCache();
 
-        return $return;
+        return true;
     }
 
     /**
      * @inheritDoc
+     * @throws ConnectionException
+     * @throws QueryException
      */
-    public function addColumn($strTable, $strColumn, $strDatatype, $bitNull = null, $strDefault = null)
+    public function addColumn(string $table, string $column, DataType $dataType, ?bool $nullable = null, ?string $default = null): bool
     {
-        if (!$this->bitConnected) {
+        if (!$this->connected) {
             $this->dbconnect();
         }
 
-        if ($this->hasColumn($strTable, $strColumn)) {
+        if ($this->hasColumn($table, $column)) {
             return true;
         }
 
-        $return = $this->objDbDriver->addColumn($strTable, $strColumn, $strDatatype, $bitNull, $strDefault);
+        $return = $this->dbDriver->addColumn($table, $column, $dataType, $nullable, $default);
 
         if (!$return) {
-            $error = $this->objDbDriver->getError();
+            $error = $this->dbDriver->getError();
             throw new AddColumnException(
                 'Could not add column: ' . $error,
-                $strTable,
-                $strColumn,
-                $strDatatype,
-                $bitNull,
-                $strDefault
+                $table,
+                $column,
+                $dataType,
+                $nullable,
+                $default,
             );
         }
 
         $this->flushTablesCache();
 
-        return $return;
+        return true;
     }
 
     /**
      * @inheritDoc
+     * @throws ConnectionException
      */
-    public function removeColumn($strTable, $strColumn)
+    public function removeColumn($tableName, $column): bool
     {
-        if (!$this->bitConnected) {
+        if (!$this->connected) {
             $this->dbconnect();
         }
 
-        $return = $this->objDbDriver->removeColumn($strTable, $strColumn);
+        $return = $this->dbDriver->removeColumn($tableName, $column);
 
         if (!$return) {
-            $error = $this->objDbDriver->getError();
-            throw new RemoveColumnException('Could not remove column: ' . $error, $strTable, $strColumn);
+            $error = $this->dbDriver->getError();
+            throw new RemoveColumnException('Could not remove column: ' . $error, $tableName, $column);
         }
 
         $this->flushTablesCache();
 
-        return $return;
+        return true;
     }
 
     /**
      * @inheritDoc
      */
-    public function hasColumn($strTable, $strColumn)
+    public function hasColumn(string $tableName, string $column): bool
     {
-        return $this->objDbDriver->hasColumn($strTable, $strColumn);
+        return $this->dbDriver->hasColumn($tableName, $column);
     }
 
     /**
      * @inheritDoc
+     * @throws ConnectionException
      */
-    public function hasTable($strTable)
+    public function hasTable(string $tableName): bool
     {
-        return in_array($strTable, $this->getTables());
+        return in_array($tableName, $this->getTables(), true);
     }
 
     /**
-     * Parses a query to eliminate unnecessary characters such as whitespaces
-     *
-     * @param string $strQuery
-     *
-     * @return string
+     * Parses a query to eliminate unnecessary characters such as whitespaces.
      */
-    private function processQuery($strQuery)
+    private function processQuery(string $query): string
     {
-        $strQuery = trim($strQuery);
-        $arrSearch = array(
-            "    ",
-            "   ",
-            "  "
-        );
-        $arrReplace = array(
-            " ",
-            " ",
-            " "
-        );
+        $query = trim($query);
+        $search = ['    ', '   ', '  '];
+        $replace = [' ', ' ', ' '];
 
-        $strQuery = str_replace($arrSearch, $arrReplace, $strQuery);
-
-        return $strQuery;
+        return str_replace($search, $replace, $query);
     }
 
     /**
-     * Queries the current db-driver about common information
+     * Queries the current db-driver about common information.
      *
-     * @return mixed|string
+     * @throws ConnectionException
      */
-    public function getDbInfo()
+    public function getDbInfo(): array
     {
-        if (!$this->bitConnected) {
+        if (!$this->connected) {
             $this->dbconnect();
         }
 
-        if ($this->objDbDriver != null) {
-            return $this->objDbDriver->getDbInfo();
+        if (!$this->dbDriver === null) {
+            return [];
         }
 
-        return "";
+        return $this->dbDriver->getDbInfo();
     }
-
 
     /**
      * Returns the number of queries sent to the database
-     * including those solved by the cache
-     *
-     * @return int
+     * including those solved by the cache.
      */
-    public function getNumber()
+    public function getNumber(): int
     {
-        return $this->intNumber;
+        return $this->number;
     }
 
     /**
-     * Returns the number of queries solved by the cache
-     *
-     * @return int
+     * Returns the number of queries solved by the cache.
      */
-    public function getNumberCache()
+    public function getNumberCache(): int
     {
-        return $this->intNumberCache;
+        return $this->numberCache;
     }
 
     /**
-     * Returns the number of items currently in the query-cache
-     *
-     * @return  int
+     * Returns the number of items currently in the query-cache.
      */
-    public function getCacheSize()
+    public function getCacheSize(): int
     {
-        return count($this->arrQueryCache);
+        return count($this->queryCache);
     }
 
     /**
-     * Internal wrapper to dbsafeString, used to process a complete array of parameters
+     * An internal wrapper to dbsafeString, used to process a complete array of parameters
      * as used by prepared statements.
      *
-     * @param array $arrParams
-     * @param array $arrEscapes An array of boolean for each param, used to block the escaping of html-special chars.
+     * @param array $escapes An array of boolean for each param, used to block the escaping of html-special chars.
      *                          If not passed, all params will be cleaned.
      *
-     * @return array
-     * @since 3.4
      * @see Db::dbsafeString($strString, $bitHtmlSpecialChars = true)
      */
-    private function dbsafeParams($arrParams, $arrEscapes = array())
+    private function dbsafeParams(array $params, array $escapes = []): array
     {
         $replace = [];
-        foreach ($arrParams as $intKey => $strParam) {
-            if ($strParam instanceof EscapeableParameterInterface && !$strParam->isEscape()) {
-                $replace[$intKey] = $strParam->getValue();
+        foreach ($params as $key => $param) {
+            if ($param instanceof EscapeableParameterInterface && !$param->isEscape()) {
+                $replace[$key] = $param->getValue();
+
                 continue;
             }
 
-            if (isset($arrEscapes[$intKey])) {
-                $strParam = $this->dbsafeString($strParam, $arrEscapes[$intKey], false);
+            if (isset($escapes[$key])) {
+                $param = $this->dbsafeString($param, $escapes[$key], false);
             } else {
-                $strParam = $this->dbsafeString($strParam, true, false);
+                $param = $this->dbsafeString($param, true, false);
             }
-            $replace[$intKey] = $strParam;
+            $replace[$key] = $param;
         }
+
         return $replace;
     }
 
     /**
-     * Makes a string db-safe
-     *
-     * @param string $strString
-     * @param bool $bitHtmlSpecialChars
-     * @param bool $bitAddSlashes
+     * Makes a string db-safe.
      *
      * @return int|null|string
      * @deprecated we need to get rid of this
      */
-    public function dbsafeString($strString, $bitHtmlSpecialChars = true, $bitAddSlashes = true)
+    public function dbsafeString(mixed $input, bool $htmlSpecialChars = true, bool $addSlashes = true): mixed
     {
-        //skip for numeric values to avoid php type juggling/autoboxing
-        if (is_float($strString) || is_int($strString)) {
-            return $strString;
-        } else {
-            if (is_bool($strString)) {
-                return (int)$strString;
-            }
+        // skip for numeric values to avoid php type juggling/autoboxing
+        if (is_float($input) || is_int($input)) {
+            return $input;
         }
 
-        if ($strString === null) {
+        if (is_bool($input)) {
+            return (int) $input;
+        }
+
+        if ($input === null) {
             return null;
         }
 
-        if (!self::$bitDbSafeStringEnabled) {
-            return $strString;
+        if (!self::$dbSafeStringEnabled) {
+            return $input;
         }
 
-        //escape special chars
-        if ($bitHtmlSpecialChars) {
-            $strString = html_entity_decode((string)$strString, ENT_COMPAT, "UTF-8");
-            $strString = htmlspecialchars($strString, ENT_COMPAT, "UTF-8");
+        // escape special chars
+        if ($htmlSpecialChars) {
+            $input = html_entity_decode((string) $input, ENT_COMPAT, 'UTF-8');
+            $input = htmlspecialchars($input, ENT_COMPAT, 'UTF-8');
         }
 
-        if ($bitAddSlashes) {
-            $strString = addslashes($strString);
+        if ($addSlashes) {
+            $input = addslashes($input);
         }
 
-        return $strString;
+        return $input;
     }
 
     /**
-     * Method to flush the query-cache
-     *
-     * @return void
+     * Method to flush the query-cache.
      */
-    public function flushQueryCache()
+    public function flushQueryCache(): void
     {
-        $this->arrQueryCache = array();
+        $this->queryCache = [];
     }
 
     /**
      * Method to flush the table-cache.
      * Since the tables won't change during regular operations,
-     * flushing the tables cache is only required during package updates / installations
-     *
-     * @return void
+     * flushing the tables cache is only required during package updates / installations.
      */
-    public function flushTablesCache()
+    public function flushTablesCache(): void
     {
-        $this->arrTablesCache = [];
+        $this->tablesCache = [];
     }
 
     /**
      * Helper to flush the precompiled queries stored at the db-driver.
      * Use this method with great care!
      *
-     * @return void
+     * @throws ConnectionException
      */
-    public function flushPreparedStatementsCache()
+    public function flushPreparedStatementsCache(): void
     {
-        if (!$this->bitConnected) {
+        if (!$this->connected) {
             $this->dbconnect();
         }
 
-        $this->objDbDriver->flushQueryCache();
+        $this->dbDriver->flushQueryCache();
     }
 
     /**
      * @inheritDoc
      */
-    public function encloseColumnName($strColumn)
+    public function encloseColumnName(string $column): string
     {
-        return $this->objDbDriver->encloseColumnName($strColumn);
+        return $this->dbDriver->encloseColumnName($column);
     }
 
     /**
      * @inheritDoc
      */
-    public function encloseTableName($strTable)
+    public function encloseTableName(string $tableName): string
     {
-        return $this->objDbDriver->encloseTableName($strTable);
+        return $this->dbDriver->encloseTableName($tableName);
     }
 
     /**
@@ -1223,109 +1216,92 @@ class Connection implements ConnectionInterface
      * May be used by other classes in order to test some credentials,
      * e.g. the installer.
      * The connection established will be closed directly and is not usable by other modules.
-     *
-     * @param ConnectionParameters $objCfg
-     * @return bool
      */
-    public function validateDbCxData(ConnectionParameters $objCfg)
+    public function validateDatabaseConnectionData(ConnectionParameters $config): bool
     {
         try {
-            $this->driverFactory->factory($objCfg->getDriver())->dbconnect($objCfg);
+            $this->driverFactory->factory($config->getDriver())->dbconnect($config);
 
             return true;
-        } catch (ConnectionException $objEx) {
-        } catch (DriverNotFoundException $objEx) {
+        } catch (ConnectionException | DriverNotFoundException) {
         }
 
         return false;
     }
 
-    /**
-     * @inheritDoc
-     */
-    public function getBitConnected()
+    public function isConnected(): bool
     {
-        return $this->bitConnected;
+        return $this->connected;
     }
 
     /**
      * For some database vendors we need to escape the backslash character even if we are using prepared statements. This
-     * method unifies the behaviour. In order to select a column which contains a backslash you need to escape the value
-     * with this method
-     *
-     * @param string $strValue
-     *
-     * @return mixed
+     * method unifies the behaviour. In order to select a column, which contains a backslash you need to escape the value
+     * with this method.
      */
-    public function escape($strValue)
+    public function escape(mixed $value): mixed
     {
-        return $this->objDbDriver->escape($strValue);
+        return $this->dbDriver->escape($value);
     }
 
     /**
      * @inheritDoc
      */
-    public function prettifyQuery($strQuery, $arrParams)
+    public function prettifyQuery(string $query, array $params): string
     {
-        foreach ($arrParams as $strOneParam) {
-            if (!is_numeric($strOneParam) && $strOneParam !== null) {
-                $strOneParam = "'{$strOneParam}'";
+        foreach ($params as $param) {
+            if (!is_numeric($param) && $param !== null) {
+                $param = "'$param'";
             }
 
-            if ($strOneParam === null) {
-                $strOneParam = 'null';
-            } elseif (is_int($strOneParam) || is_float($strOneParam)) {
-                $strOneParam = (string) $strOneParam;
+            if ($param === null) {
+                $param = 'null';
+            } elseif (is_int($param) || is_float($param)) {
+                $param = (string) $param;
             }
 
-            $intPos = strpos($strQuery, '?');
-            if ($intPos !== false) {
-                $strQuery = substr_replace($strQuery, $strOneParam, $intPos, 1);
+            $pos = strpos($query, '?');
+            if ($pos !== false) {
+                $query = substr_replace($query, $param, $pos, 1);
             }
         }
 
-        return $strQuery;
+        return $query;
     }
 
     /**
      * @inheritDoc
      */
-    public function appendLimitExpression($strQuery, $intStart, $intEnd)
+    public function appendLimitExpression(string $query, int $start, int $end): string
     {
-        return $this->objDbDriver->appendLimitExpression($strQuery, $intStart, $intEnd);
+        return $this->dbDriver->appendLimitExpression($query, $start, $end);
     }
 
-    /**
-     * @inheritDoc
-     */
-    public function getConcatExpression(array $parts)
+    public function getConcatExpression(array $parts): string
     {
-        return $this->objDbDriver->getConcatExpression($parts);
+        return $this->dbDriver->getConcatExpression($parts);
     }
 
     /**
      * @inheritDoc
      */
-    public function convertToDatabaseValue($value, string $type)
+    public function convertToDatabaseValue(mixed $value, DataType $type): mixed
     {
-        return $this->objDbDriver->convertToDatabaseValue($value, $type);
+        return $this->dbDriver->convertToDatabaseValue($value, $type);
     }
 
-    /**
-     * @inheritDoc
-     */
     public function getLeastExpression(array $parts): string
     {
-        return $this->objDbDriver->getLeastExpression($parts);
+        return $this->dbDriver->getLeastExpression($parts);
     }
 
     public function getSubstringExpression(string $value, int $offset, ?int $length): string
     {
-        return $this->objDbDriver->getSubstringExpression($value, $offset, $length);
+        return $this->dbDriver->getSubstringExpression($value, $offset, $length);
     }
 
     public function getStringLengthExpression(string $targetString): string
     {
-        return $this->objDbDriver->getStringLengthExpression($targetString);
+        return $this->dbDriver->getStringLengthExpression($targetString);
     }
 }

--- a/src/Connection.php
+++ b/src/Connection.php
@@ -573,24 +573,24 @@ class Connection implements ConnectionInterface
 
         $query = $this->prettifyQuery($query, $params);
 
-        $strErrorCode = "Error in query\n\n";
-        $strErrorCode .= "Error:\n";
-        $strErrorCode .= $error . "\n\n";
-        $strErrorCode .= "Query:\n";
-        $strErrorCode .= $query . "\n";
-        $strErrorCode .= "\n\n";
-        $strErrorCode .= 'Params: ' . implode(', ', $params) . "\n";
-        $strErrorCode .= "Callstack:\n";
+        $errorCode = "Error in query\n\n";
+        $errorCode .= "Error:\n";
+        $errorCode .= $error . "\n\n";
+        $errorCode .= "Query:\n";
+        $errorCode .= $query . "\n";
+        $errorCode .= "\n\n";
+        $errorCode .= 'Params: ' . implode(', ', $params) . "\n";
+        $errorCode .= "Callstack:\n";
         if (function_exists('debug_backtrace')) {
-            $arrStack = debug_backtrace();
+            $stack = debug_backtrace();
 
-            foreach ($arrStack as $arrValue) {
-                $strErrorCode .= ($arrValue['file'] ?? 'n.a.') . "\n\t Row " . ($arrValue['line'] ?? 'n.a.') . ', function ' . $arrValue['function'] . "\n";
+            foreach ($stack as $value) {
+                $errorCode .= ($value['file'] ?? 'n.a.') . "\n\t Row " . ($value['line'] ?? 'n.a.') . ', function ' . $value['function'] . "\n";
             }
         }
 
         // send a warning to the logger
-        $this->logger?->error($strErrorCode);
+        $this->logger?->error($errorCode);
 
         throw new QueryException($error, $query, $params);
     }
@@ -1101,7 +1101,7 @@ class Connection implements ConnectionInterface
      * @param array $escapes An array of boolean for each param, used to block the escaping of html-special chars.
      *                          If not passed, all params will be cleaned.
      *
-     * @see Db::dbsafeString($strString, $bitHtmlSpecialChars = true)
+     * @see Db::dbsafeString($string, $htmlSpecialChars = true)
      */
     private function dbsafeParams(array $params, array $escapes = []): array
     {

--- a/src/ConnectionInterface.php
+++ b/src/ConnectionInterface.php
@@ -104,7 +104,7 @@ interface ConnectionInterface extends DoctrineConnectionInterface
     /**
      * Creates a single query in order to insert multiple rows at one time.
      * For most databases, this will create s.th. like
-     * INSERT INTO $strTable ($arrColumns) VALUES (?, ?), (?, ?)...
+     * INSERT INTO $table ($columns) VALUES (?, ?), (?, ?)...
      *
      * @param string[] $columns
      * @throws QueryException

--- a/src/ConnectionParameters.php
+++ b/src/ConnectionParameters.php
@@ -14,148 +14,75 @@ declare(strict_types=1);
 namespace Artemeon\Database;
 
 /**
- * Simple dto to hold all relevant params required to open a db connection
- *
- * @author sidler@mulchprod.de
- * @since 5.1
+ * Simple DTO to hold all relevant params required to open a db connection.
  */
-class ConnectionParameters
+final class ConnectionParameters
 {
     public const SQLITE3_BASE_PATH = 'sqlite3_base_path';
 
-    /**
-     * @var string
-     */
-    private $host;
+    private array $attributes = [];
 
-    /**
-     * @var string
-     */
-    private $username;
-
-    /**
-     * @var string
-     */
-    private $password;
-
-    /**
-     * @var string
-     */
-    private $database;
-
-    /**
-     * @var int
-     */
-    private $port;
-
-    /**
-     * @var string
-     */
-    private $driver;
-
-    /**
-     * @var array
-     */
-    private $attributes;
-
-    /**
-     * @param string $host
-     * @param string $username
-     * @param string $password
-     * @param string $database
-     * @param int|null $port
-     * @param string $driver
-     */
-    public function __construct(string $host, string $username, string $password, string $database, ?int $port, string $driver)
-    {
-        $this->host = $host;
-        $this->username = $username;
-        $this->password = $password;
-        $this->database = $database;
-        $this->port = $port;
-        $this->driver = $driver;
-        $this->attributes = [];
+    public function __construct(
+        private readonly string $host,
+        private readonly string $username,
+        private readonly string $password,
+        private readonly string $database,
+        private readonly ?int $port,
+        private readonly string $driver
+    ) {
     }
 
-    /**
-     * @return string
-     */
     public function getHost(): string
     {
         return $this->host;
     }
 
-    /**
-     * @return string
-     */
     public function getUsername(): string
     {
         return $this->username;
     }
 
-    /**
-     * @return string
-     */
     public function getPassword(): string
     {
         return $this->password;
     }
 
-    /**
-     * @return string
-     */
     public function getDatabase(): string
     {
         return $this->database;
     }
 
-    /**
-     * @return int
-     */
     public function getPort(): ?int
     {
         return $this->port;
     }
 
-    /**
-     * @return string
-     */
     public function getDriver(): string
     {
         return $this->driver;
     }
 
-    /**
-     * @param string $key
-     * @param mixed $value
-     */
-    public function setAttribute(string $key, $value)
+    public function setAttribute(string $key, mixed $value): self
     {
         $this->attributes[$key] = $value;
+
+        return $this;
     }
 
-    /**
-     * @param string $key
-     * @return mixed|null
-     */
-    public function getAttribute(string $key)
+    public function getAttribute(string $key): mixed
     {
         return $this->attributes[$key] ?? null;
     }
 
-    /**
-     * @param array $data
-     * @return ConnectionParameters
-     */
-    public static function fromArray(array $data): ConnectionParameters
+    public static function fromArray(array $data): self
     {
-        return new static(
+        return new self(
             $data['dbhost'] ?? '',
             $data['dbusername'] ?? '',
             $data['dbpassword'] ?? '',
             $data['dbname'] ?? '',
             isset($data['dbport']) ? (int) $data['dbport'] : 0,
-            $data['dbdriver'] ?? ''
+            $data['dbdriver'] ?? '',
         );
     }
 }

--- a/src/DoctrineConnectionInterface.php
+++ b/src/DoctrineConnectionInterface.php
@@ -13,9 +13,14 @@ declare(strict_types=1);
 
 namespace Artemeon\Database;
 
+use Generator;
+
 /**
- * Interface which is compatible to the Doctrine DBAL Connection class {@link https://github.com/doctrine/dbal/blob/3.3.x/src/Connection.php}
- * If your service uses only those new methods it is recommended to type hint against this DoctrineConnectionInterface interface instead of the ConnectionInterface.
+ * Interface, which is compatible to the Doctrine DBAL Connection class
+ * {@link https://github.com/doctrine/dbal/blob/3.3.x/src/Connection.php}.
+ *
+ * If your service uses only those new methods it is recommended to type hint against this DoctrineConnectionInterface
+ * interface instead of the ConnectionInterface.
  */
 interface DoctrineConnectionInterface
 {
@@ -44,12 +49,12 @@ interface DoctrineConnectionInterface
      * Prepares and executes an SQL query and returns the result as an iterator over rows represented
      * as associative arrays.
      */
-    public function iterateAssociative(string $query, array $params = []): \Generator;
+    public function iterateAssociative(string $query, array $params = []): Generator;
 
     /**
      * Prepares and executes an SQL query and returns the result as an iterator over the first column values.
      */
-    public function iterateColumn(string $query, array $params = []): \Generator;
+    public function iterateColumn(string $query, array $params = []): Generator;
 
     /**
      * Executes an SQL statement with the given parameters and returns the number of affected rows.
@@ -65,17 +70,17 @@ interface DoctrineConnectionInterface
 
     /**
      * Creates a simple insert for a single row where the values parameter is an associative array with column names to
-     * value mapping
+     * value mapping.
      */
     public function insert(string $tableName, array $values, ?array $escapes = null): int;
 
     /**
-     * Updates a row on the provided table by the identifier columns
+     * Updates a row on the provided table by the identifier columns.
      */
     public function update(string $tableName, array $values, array $identifier, ?array $escapes = null): int;
 
     /**
-     * Deletes a row on the provided table by the identifier columns
+     * Deletes a row on the provided table by the identifier columns.
      */
     public function delete(string $tableName, array $identifier): int;
 }

--- a/src/Driver/MysqliDriver.php
+++ b/src/Driver/MysqliDriver.php
@@ -195,11 +195,11 @@ class MysqliDriver extends DriverAbstract
         call_user_func_array([$statement, 'bind_result'], $params);
 
         while ($statement->fetch()) {
-            $arrSingleRow = [];
+            $singleRow = [];
             foreach ($row as $key => $val) {
-                $arrSingleRow[$key] = $val;
+                $singleRow[$key] = $val;
             }
-            yield $arrSingleRow;
+            yield $singleRow;
         }
 
         $statement->free_result();
@@ -214,21 +214,21 @@ class MysqliDriver extends DriverAbstract
         $mappedColumns = [];
         $keyValuePairs = [];
 
-        foreach ($columns as $strOneCol) {
+        foreach ($columns as $column) {
             $placeholders[] = '?';
-            $mappedColumns[] = $this->encloseColumnName($strOneCol);
-            $keyValuePairs[] = $this->encloseColumnName($strOneCol) . ' = ?';
+            $mappedColumns[] = $this->encloseColumnName($column);
+            $keyValuePairs[] = $this->encloseColumnName($column) . ' = ?';
         }
 
         $enclosedTableName = $this->encloseTableName($table);
 
-        $strQuery = "INSERT INTO $enclosedTableName (" . implode(
+        $query = "INSERT INTO $enclosedTableName (" . implode(
                 ', ',
                 $mappedColumns
             ) . ') VALUES (' . implode(', ', $placeholders) . ')
                         ON DUPLICATE KEY UPDATE ' . implode(', ', $keyValuePairs);
 
-        return $this->_pQuery($strQuery, array_merge($values, $values));
+        return $this->_pQuery($query, array_merge($values, $values));
     }
 
     /**
@@ -424,8 +424,8 @@ class MysqliDriver extends DriverAbstract
      */
     public function hasIndex($table, $name): bool
     {
-        $arrIndex = iterator_to_array($this->getPArray("SHOW INDEX FROM $table WHERE Key_name = ?", [$name]), false);
-        return count($arrIndex) > 0;
+        $index = iterator_to_array($this->getPArray("SHOW INDEX FROM $table WHERE Key_name = ?", [$name]), false);
+        return count($index) > 0;
     }
 
     /**
@@ -511,16 +511,16 @@ class MysqliDriver extends DriverAbstract
 
         if ($this->handlesDumpCompression()) {
             $fileName .= '.gz';
-            $strCommand = $dumpBin . ' -h' . $this->config->getHost() . ' -u' . $this->config->getUsername(
+            $command = $dumpBin . ' -h' . $this->config->getHost() . ' -u' . $this->config->getUsername(
                 ) . $paramPass . ' -P' . $this->config->getPort() . ' ' . $this->config->getDatabase(
                 ) . ' ' . $tablesString . " | gzip > \"" . $fileName . "\"";
         } else {
-            $strCommand = $dumpBin . ' -h' . $this->config->getHost() . ' -u' . $this->config->getUsername(
+            $command = $dumpBin . ' -h' . $this->config->getHost() . ' -u' . $this->config->getUsername(
                 ) . $paramPass . ' -P' . $this->config->getPort() . ' ' . $this->config->getDatabase(
                 ) . ' ' . $tablesString . " > \"" . $fileName . "\"";
         }
 
-        $this->runCommand($strCommand);
+        $this->runCommand($command);
 
         return true;
     }
@@ -539,16 +539,16 @@ class MysqliDriver extends DriverAbstract
         $restoreBin = (new ExecutableFinder())->find($this->restoreBin);
 
         if ($this->handlesDumpCompression() && pathinfo($fileName, PATHINFO_EXTENSION) === 'gz') {
-            $strCommand = " gunzip -c \"" . $fileName . "\" | " . $restoreBin . ' -h' . $this->config->getHost(
+            $command = " gunzip -c \"" . $fileName . "\" | " . $restoreBin . ' -h' . $this->config->getHost(
                 ) . ' -u' . $this->config->getUsername() . $paramPass . ' -P' . $this->config->getPort(
                 ) . ' ' . $this->config->getDatabase();
         } else {
-            $strCommand = $restoreBin . ' -h' . $this->config->getHost() . ' -u' . $this->config->getUsername(
+            $command = $restoreBin . ' -h' . $this->config->getHost() . ' -u' . $this->config->getUsername(
                 ) . $paramPass . ' -P' . $this->config->getPort() . ' ' . $this->config->getDatabase(
                 ) . " < \"" . $fileName . "\"";
         }
 
-        $this->runCommand($strCommand);
+        $this->runCommand($command);
 
         return true;
     }

--- a/src/Driver/Oci8Driver.php
+++ b/src/Driver/Oci8Driver.php
@@ -247,9 +247,9 @@ class Oci8Driver extends DriverAbstract
         }
 
         // this was the old way, we're now no longer loading LOBS by default
-        // while ($arrRow = oci_fetch_array($objStatement, OCI_ASSOC + OCI_RETURN_NULLS + OCI_RETURN_LOBS)) {
-        while ($arrRow = oci_fetch_assoc($statement)) {
-            yield $this->parseResultRow($arrRow);
+        // while ($row = oci_fetch_array($objStatement, OCI_ASSOC + OCI_RETURN_NULLS + OCI_RETURN_LOBS)) {
+        while ($row = oci_fetch_assoc($statement)) {
+            yield $this->parseResultRow($row);
         }
 
         oci_free_statement($statement);
@@ -438,17 +438,17 @@ class Oci8Driver extends DriverAbstract
         if ($oldColumnName !== $newColumnName) {
             $enclosedOldColumnName = $this->encloseColumnName($oldColumnName);
 
-            $bitReturn = $this->_pQuery(
+            $output = $this->_pQuery(
                 "ALTER TABLE $enclosedTableName RENAME COLUMN $enclosedOldColumnName TO $enclosedNewColumnName",
                 [],
             );
         } else {
-            $bitReturn = true;
+            $output = true;
         }
 
         $mappedDataType = $this->getDatatype($newDataType);
 
-        return $bitReturn && $this->_pQuery(
+        return $output && $this->_pQuery(
                 "ALTER TABLE $enclosedTableName MODIFY ( $enclosedNewColumnName $mappedDataType )",
                 [],
             );
@@ -520,7 +520,7 @@ class Oci8Driver extends DriverAbstract
      */
     public function hasIndex($table, $name): bool
     {
-        $arrIndex = iterator_to_array(
+        $index = iterator_to_array(
             $this->getPArray(
                 'SELECT INDEX_NAME FROM USER_INDEXES WHERE TABLE_NAME = ? AND INDEX_NAME = ?',
                 [strtoupper($table), strtoupper($name)],
@@ -528,7 +528,7 @@ class Oci8Driver extends DriverAbstract
             false,
         );
 
-        return count($arrIndex) > 0;
+        return count($index) > 0;
     }
 
     /**
@@ -624,10 +624,10 @@ class Oci8Driver extends DriverAbstract
         $tablesString = implode(',', $tables);
 
         $dumpBin = (new ExecutableFinder())->find($this->dumpBin);
-        $strCommand = $dumpBin . ' ' . $this->config->getUsername() . '/' . $this->config->getPassword(
+        $command = $dumpBin . ' ' . $this->config->getUsername() . '/' . $this->config->getPassword(
             ) . ' CONSISTENT=n TABLES=' . $tablesString . " FILE='" . $fileName . "'";
 
-        $this->runCommand($strCommand);
+        $this->runCommand($command);
 
         return true;
     }
@@ -728,8 +728,8 @@ class Oci8Driver extends DriverAbstract
 
         if (self::$is12c) {
             // TODO: 12c has a new offset syntax - lets see if it's really faster
-            $intDelta = $end - $start + 1;
-            return $query . " OFFSET $start ROWS FETCH NEXT $intDelta ROWS ONLY";
+            $delta = $end - $start + 1;
+            return $query . " OFFSET $start ROWS FETCH NEXT $delta ROWS ONLY";
         }
 
         $start++;

--- a/src/Driver/Oci8Driver.php
+++ b/src/Driver/Oci8Driver.php
@@ -22,248 +22,276 @@ use Artemeon\Database\Schema\Table;
 use Artemeon\Database\Schema\TableColumn;
 use Artemeon\Database\Schema\TableIndex;
 use Artemeon\Database\Schema\TableKey;
+use Generator;
 use Symfony\Component\Process\ExecutableFinder;
 
+use UnexpectedValueException;
+
+use const OCI_COMMIT_ON_SUCCESS;
+use const OCI_NO_AUTO_COMMIT;
+
 /**
- * db-driver for oracle using the ovi8-interface
- *
- * @package module_system
- * @author sidler@mulchprod.de
- * @since 3.4.1
+ * DB-driver for Oracle using the ovi8-interface.
  */
 class Oci8Driver extends DriverAbstract
 {
+    /** @var resource | false */
+    private $linkDB;
 
-    private $linkDB; //DB-Link
-    /** @var ConnectionParameters  */
-    private $objCfg = null;
+    private ConnectionParameters $config;
 
-    private $strDumpBin = "exp"; // Binary to dump db (if not in path, add the path here)
+    private string $dumpBin = 'exp'; // Binary to dump db (if not in path, add the path here)
     // /usr/lib/oracle/xe/app/oracle/product/10.2.0/server/bin/
-    private $strRestoreBin = "imp"; //Binary to restore db (if not in path, add the path here)
+    private string $restoreBin = 'imp'; // Binary to restore db (if not in path, add the path here)
 
-    private $bitTxOpen = false;
+    private bool $txOpen = false;
 
-    private $objErrorStmt = null;
+    private $errorStmt;
 
     /**
-     * Flag whether the sring comparison method (case sensitive / insensitive) should be reset back to default after the current query
-     *
-     * @var bool
+     * Flag whether the string comparison method (case sensitive / insensitive) should be reset back to default after the current query.
      */
-    private $bitResetOrder = false;
+    private bool $resetOrder = false;
 
     /**
      * @inheritdoc
+     * @throws QueryException
      */
-    public function dbconnect(ConnectionParameters $objParams)
+    public function dbconnect(ConnectionParameters $params): bool
     {
-        $port = $objParams->getPort();
+        $port = $params->getPort();
         if (empty($port)) {
             $port = 1521;
         }
-        $this->objCfg = $objParams;
+        $this->config = $params;
 
-        //try to set the NLS_LANG env attribute
-        putenv("NLS_LANG=American_America.UTF8");
+        // Try to set the NLS_LANG env attribute
+        putenv('NLS_LANG=American_America.UTF8');
 
-        $this->linkDB = oci_pconnect($this->objCfg->getUsername(), $this->objCfg->getPassword(), $this->objCfg->getHost().":".$port."/".$this->objCfg->getDatabase(), "AL32UTF8");
+        $this->linkDB = oci_pconnect(
+            $this->config->getUsername(),
+            $this->config->getPassword(),
+            $this->config->getHost() . ':' . $port . '/' . $this->config->getDatabase(),
+            'AL32UTF8',
+        );
 
         if ($this->linkDB !== false) {
-            oci_set_client_info($this->linkDB, "ARTEMEON AGP");
-            oci_set_client_identifier($this->linkDB, "ARTEMEON AGP");
+            oci_set_client_info($this->linkDB, 'ARTEMEON AGP');
+            oci_set_client_identifier($this->linkDB, 'ARTEMEON AGP');
             $this->_pQuery("ALTER SESSION SET NLS_NUMERIC_CHARACTERS='.,'", []);
-            $this->_pQuery("ALTER SESSION SET DEFAULT_COLLATION=BINARY_CI", []);
+            $this->_pQuery('ALTER SESSION SET DEFAULT_COLLATION=BINARY_CI', []);
+
             return true;
         }
 
-        throw new ConnectionException("Error connecting to database");
+        throw new ConnectionException('Error connecting to database');
     }
 
     /**
      * @inheritDoc
      */
-    public function dbclose()
+    public function dbclose(): void
     {
-        //do n.th. to keep the persistent connection
-        //oci_close($this->linkDB);
+        // Do n.th. to keep the persistent connection
+        // oci_close($this->linkDB);
     }
 
     /**
      * @inheritDoc
      */
-    public function triggerMultiInsert($strTable, $arrColumns, $arrValueSets, ConnectionInterface $objDb, ?array $arrEscapes): bool
-    {
-        $safeColumns = array_map(function ($column) { return $this->encloseColumnName($column); }, $arrColumns);
+    public function triggerMultiInsert(
+        string $table,
+        array $columns,
+        array $valueSets,
+        ConnectionInterface $database,
+        ?array $escapes
+    ): bool {
+        $safeColumns = array_map(function ($column) {
+            return $this->encloseColumnName($column);
+        }, $columns);
         $paramsPlaceholder = '(' . implode(',', array_fill(0, count($safeColumns), '?')) . ')';
         $columnNames = ' (' . implode(',', $safeColumns) . ') ';
 
         $params = [];
         $escapeValues = [];
         $insertStatement = 'INSERT ALL ';
-        foreach ($arrValueSets as $valueSet) {
+        foreach ($valueSets as $valueSet) {
             $params[] = array_values($valueSet);
-            if ($arrEscapes !== null) {
-                $escapeValues[] = $arrEscapes;
+            if ($escapes !== null) {
+                $escapeValues[] = $escapes;
             }
-            $insertStatement .= ' INTO ' . $this->encloseTableName($strTable) . ' ' . $columnNames . ' VALUES ' . $paramsPlaceholder . ' ';
+            $insertStatement .= ' INTO ' . $this->encloseTableName(
+                    $table
+                ) . ' ' . $columnNames . ' VALUES ' . $paramsPlaceholder . ' ';
         }
         $insertStatement .= ' SELECT * FROM dual';
 
-        return $objDb->_pQuery($insertStatement, array_merge(...$params), $escapeValues !== [] ? array_merge(...$escapeValues) : []);
+        return $database->_pQuery(
+            $insertStatement,
+            array_merge(...$params),
+            $escapeValues !== [] ? array_merge(...$escapeValues) : []
+        );
     }
 
     /**
      * @inheritDoc
+     * @throws QueryException
      */
-    public function _pQuery($strQuery, $arrParams)
+    public function _pQuery(string $query, array $params): bool
     {
-        $strQuery = $this->processQuery($strQuery);
-        $objStatement = $this->getParsedStatement($strQuery);
-        if ($objStatement === false) {
-            throw new QueryException('Could not prepare statement: ' . $this->getError(), $strQuery, $arrParams);
+        $query = $this->processQuery($query);
+        $statement = $this->getParsedStatement($query);
+        if ($statement === false) {
+            throw new QueryException('Could not prepare statement: ' . $this->getError(), $query, $params);
         }
 
-        foreach ($arrParams as $intPos => $strValue) {
-            if (!oci_bind_by_name($objStatement, ":".($intPos + 1), $arrParams[$intPos])) {
-                //echo "oci_bind_by_name failed to bind at pos >".$intPos."<, \n value: ".$strValue."\nquery: ".$strQuery;
+        foreach ($params as $pos => $value) {
+            if (!oci_bind_by_name($statement, ':' . ($pos + 1), $params[$pos])) {
+                // echo 'oci_bind_by_name failed to bind at pos >' . $pos . "<, \n value: " . $value . "\nquery: " . $query;
                 return false;
             }
         }
 
-        $bitAddon = \OCI_COMMIT_ON_SUCCESS;
-        if ($this->bitTxOpen) {
-            $bitAddon = \OCI_NO_AUTO_COMMIT;
+        $addon = OCI_COMMIT_ON_SUCCESS;
+        if ($this->txOpen) {
+            $addon = OCI_NO_AUTO_COMMIT;
         }
-        $bitResult = oci_execute($objStatement, $bitAddon);
+        $result = oci_execute($statement, $addon);
 
-        if (!$bitResult) {
-            $this->objErrorStmt = $objStatement;
-            throw new QueryException('Could not execute statement: ' . $this->getError(), $strQuery, $arrParams);
-        }
-
-        $this->intAffectedRows = oci_num_rows($objStatement);
-
-        oci_free_statement($objStatement);
-        return $bitResult;
-    }
-
-    /**
-     * @inheritDoc
-     */
-    public function insertOrUpdate($strTable, $arrColumns, $arrValues, $arrPrimaryColumns)
-    {
-
-        //return parent::insertOrUpdate($strTable, $arrColumns, $arrValues, $arrPrimaryColumns);
-
-        $arrPlaceholder = array();
-        $arrMappedColumns = array();
-        $arrKeyValuePairs = array();
-
-
-        $arrParams = array();
-        $arrPrimaryCompares = array();
-
-        foreach ($arrColumns as $intKey => $strOneCol) {
-            $arrPlaceholder[] = "?";
-            $arrMappedColumns[] = $this->encloseColumnName($strOneCol);
-
-            if (in_array($strOneCol, $arrPrimaryColumns)) {
-                $arrPrimaryCompares[] = $strOneCol." = ? ";
-                $arrParams[] = $arrValues[$intKey];
-            }
+        if (!$result) {
+            $this->errorStmt = $statement;
+            throw new QueryException('Could not execute statement: ' . $this->getError(), $query, $params);
         }
 
-        $arrParams = array_merge($arrParams, $arrValues);
+        $this->affectedRowsCount = oci_num_rows($statement);
 
+        oci_free_statement($statement);
 
-        foreach ($arrColumns as $intKey => $strOneCol) {
-            if (!in_array($strOneCol, $arrPrimaryColumns)) {
-                $arrKeyValuePairs[] = $this->encloseColumnName($strOneCol)." = ?";
-                $arrParams[] = $arrValues[$intKey];
-            }
-        }
-
-        if (empty($arrKeyValuePairs)) {
-            $strQuery = "MERGE INTO ".$this->encloseTableName($strTable)." using dual on (".implode(" AND ", $arrPrimaryCompares).") 
-                       WHEN NOT MATCHED THEN INSERT (".implode(", ", $arrMappedColumns).") values (".implode(", ", $arrPlaceholder).")";
-        } else {
-            $strQuery = "MERGE INTO ".$this->encloseTableName($strTable)." using dual on (".implode(" AND ", $arrPrimaryCompares).") 
-                       WHEN NOT MATCHED THEN INSERT (".implode(", ", $arrMappedColumns).") values (".implode(", ", $arrPlaceholder).")
-                       WHEN MATCHED then update set ".implode(", ", $arrKeyValuePairs)."";
-        }
-        return $this->_pQuery($strQuery, $arrParams);
-    }
-
-    /**
-     * @inheritDoc
-     */
-    public function getPArray($strQuery, $arrParams): \Generator
-    {
-        $strQuery = $this->processQuery($strQuery, $arrParams);
-        $objStatement = $this->getParsedStatement($strQuery);
-
-        if ($objStatement === false) {
-            throw new QueryException('Could not prepare statement: ' . $this->getError(), $strQuery, $arrParams);
-        }
-
-        $index = 0;
-        foreach ($arrParams as $intPos => $strValue) {
-            oci_bind_by_name($objStatement, ":".(++$index), $arrParams[$intPos]);
-        }
-
-        $bitAddon = OCI_COMMIT_ON_SUCCESS;
-        if ($this->bitTxOpen) {
-            $bitAddon = OCI_NO_AUTO_COMMIT;
-        }
-
-        oci_set_prefetch($objStatement, 300);
-        $resultSet = oci_execute($objStatement, $bitAddon);
-
-        if (!$resultSet) {
-            $this->objErrorStmt = $objStatement;
-            throw new QueryException('Could not execute statement: ' . $this->getError(), $strQuery, $arrParams);
-        }
-
-        //this was the old way, we're now no longer loading LOBS by default
-        //while ($arrRow = oci_fetch_array($objStatement, OCI_ASSOC + OCI_RETURN_NULLS + OCI_RETURN_LOBS)) {
-        while ($arrRow = oci_fetch_assoc($objStatement)) {
-            yield $this->parseResultRow($arrRow);
-        }
-
-        oci_free_statement($objStatement);
-
-        if ($this->bitResetOrder) {
-            $this->setCaseSensitiveSort();
-            $this->bitResetOrder = false;
-        }
-    }
-
-    /**
-     * @inheritDoc
-     */
-    public function getError()
-    {
-        $strError = oci_error($this->objErrorStmt != null ? $this->objErrorStmt : $this->linkDB);
-        $this->objErrorStmt = null;
-        return print_r($strError, true);
-    }
-
-    /**
-     * @inheritDoc
-     */
-    public function getTables(): array
-    {
-        $generator = $this->getPArray("SELECT table_name AS name FROM ALL_TABLES WHERE owner = ?", [$this->objCfg->getUsername()]);
-        $result = [];
-        foreach ($generator as $row) {
-            $result[] = ['name' => strtolower($row['name'])];
-        }
         return $result;
     }
 
     /**
      * @inheritDoc
+     */
+    public function insertOrUpdate(string $table, array $columns, array $values, array $primaryColumns): bool
+    {
+        $placeholders = [];
+        $mappedColumns = [];
+        $keyValuePairs = [];
+
+        $params = [];
+        $primaryCompares = [];
+
+        foreach ($columns as $key => $column) {
+            $placeholders[] = '?';
+            $mappedColumns[] = $this->encloseColumnName($column);
+
+            if (in_array($column, $primaryColumns, true)) {
+                $primaryCompares[] = "$column = ? ";
+                $params[] = $values[$key];
+            }
+        }
+
+        $params = array_merge($params, $values);
+
+        foreach ($columns as $key => $column) {
+            if (!in_array($column, $primaryColumns, true)) {
+                $keyValuePairs[] = $this->encloseColumnName($column) . ' = ?';
+                $params[] = $values[$key];
+            }
+        }
+
+        $enclosedTableName = $this->encloseTableName($table);
+
+        $query = "MERGE INTO $enclosedTableName using dual on (" . implode(' AND ', $primaryCompares) . ') 
+                       WHEN NOT MATCHED THEN INSERT (' . implode(', ', $mappedColumns) . ') values (' . implode(
+                ', ',
+                $placeholders
+            ) . ')';
+
+        if (!empty($keyValuePairs)) {
+            $query .= 'WHEN MATCHED then update set ' . implode(', ', $keyValuePairs);
+        }
+
+        return $this->_pQuery($query, $params);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getPArray(string $query, array $params): Generator
+    {
+        $query = $this->processQuery($query);
+        $statement = $this->getParsedStatement($query);
+
+        if ($statement === false) {
+            throw new QueryException('Could not prepare statement: ' . $this->getError(), $query, $params);
+        }
+
+        $index = 0;
+        foreach ($params as $pos => $value) {
+            oci_bind_by_name($statement, ':' . ++$index, $params[$pos]);
+        }
+
+        $addon = OCI_COMMIT_ON_SUCCESS;
+        if ($this->txOpen) {
+            $addon = OCI_NO_AUTO_COMMIT;
+        }
+
+        oci_set_prefetch($statement, 300);
+        $resultSet = oci_execute($statement, $addon);
+
+        if (!$resultSet) {
+            $this->errorStmt = $statement;
+            throw new QueryException('Could not execute statement: ' . $this->getError(), $query, $params);
+        }
+
+        // this was the old way, we're now no longer loading LOBS by default
+        // while ($arrRow = oci_fetch_array($objStatement, OCI_ASSOC + OCI_RETURN_NULLS + OCI_RETURN_LOBS)) {
+        while ($arrRow = oci_fetch_assoc($statement)) {
+            yield $this->parseResultRow($arrRow);
+        }
+
+        oci_free_statement($statement);
+
+        if ($this->resetOrder) {
+            $this->setCaseSensitiveSort();
+            $this->resetOrder = false;
+        }
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getError(): string
+    {
+        $error = oci_error($this->errorStmt ?? $this->linkDB);
+        $this->errorStmt = null;
+
+        return print_r($error, true);
+    }
+
+    /**
+     * @inheritDoc
+     * @throws QueryException
+     */
+    public function getTables(): array
+    {
+        $generator = $this->getPArray(
+            'SELECT table_name AS name FROM ALL_TABLES WHERE owner = ?',
+            [$this->config->getUsername()]
+        );
+        $result = [];
+        foreach ($generator as $row) {
+            $result[] = ['name' => strtolower($row['name'])];
+        }
+
+        return $result;
+    }
+
+    /**
+     * @inheritDoc
+     * @throws QueryException
      */
     public function getTableInformation(string $tableName): Table
     {
@@ -271,42 +299,49 @@ class Oci8Driver extends DriverAbstract
 
         $tableName = strtoupper($tableName);
 
-        //fetch all columns
-        $columnInfo = $this->getPArray("SELECT * FROM user_tab_columns WHERE table_name = ?", [$tableName]) ?: [];
-        foreach ($columnInfo as $arrOneColumn) {
-            $col = new TableColumn(strtolower($arrOneColumn["column_name"]));
-            $col->setInternalType($this->getCoreTypeForDbType($arrOneColumn));
-            $col->setDatabaseType($this->getDatatype($col->getInternalType()));
-            $col->setNullable($arrOneColumn["nullable"] == "Y");
-            $table->addColumn($col);
+        // fetch all columns
+        $columnInfo = $this->getPArray('SELECT * FROM user_tab_columns WHERE table_name = ?', [$tableName]) ?: [];
+        foreach ($columnInfo as $column) {
+            $table->addColumn(
+                TableColumn::make(strtolower($column['column_name']))
+                    ->setInternalType($this->getCoreTypeForDbType($column))
+                    ->setDatabaseType($this->getDatatype($this->getCoreTypeForDbType($column)))
+                    ->setNullable($column['nullable'] === 'Y'),
+            );
         }
 
-        //fetch all indexes
-        $indexes = $this->getPArray("
+        // fetch all indexes
+        $indexes = $this->getPArray(
+            '
             select b.uniqueness, a.index_name, a.table_name, a.column_name
             from all_ind_columns a, all_indexes b
             where a.index_name=b.index_name
               and a.table_name = ?
-            order by a.index_name, a.column_position", [$tableName]) ?: [];
+            order by a.index_name, a.column_position',
+            [$tableName]
+        ) ?: [];
         $indexAggr = [];
         foreach ($indexes as $indexInfo) {
-            $indexAggr[$indexInfo["index_name"]] = $indexAggr[$indexInfo["index_name"]] ?? [];
-            $indexAggr[$indexInfo["index_name"]][] = $indexInfo["column_name"];
+            $indexAggr[$indexInfo['index_name']] = $indexAggr[$indexInfo['index_name']] ?? [];
+            $indexAggr[$indexInfo['index_name']][] = $indexInfo['column_name'];
         }
         foreach ($indexAggr as $key => $desc) {
             $index = new TableIndex(strtolower($key));
-            $index->setDescription(implode(", ", $desc));
+            $index->setDescription(implode(', ', $desc));
             $table->addIndex($index);
         }
 
-        //fetch all keys
-        $keys = $this->getPArray("SELECT cols.table_name, cols.column_name, cols.position, cons.status, cons.owner 
+        // fetch all keys
+        $keys = $this->getPArray(
+            "SELECT cols.table_name, cols.column_name, cols.position, cons.status, cons.owner 
             FROM all_constraints cons, all_cons_columns cols
             WHERE cols.table_name = ?
               AND cons.constraint_type = 'P'
               AND cons.constraint_name = cols.constraint_name
               AND cons.owner = cols.owner
-          ", [$tableName]) ?: [];
+          ",
+            [$tableName]
+        ) ?: [];
         foreach ($keys as $keyInfo) {
             $key = new TableKey(strtolower($keyInfo['column_name']));
             $table->addPrimaryKey($key);
@@ -318,227 +353,265 @@ class Oci8Driver extends DriverAbstract
 
 
     /**
-     * Tries to convert a column provided by the database back to the Kajona internal type constant
-     * @param $infoSchemaRow
-     * @return null|string
+     * Tries to convert a column provided by the database back to the Kajona internal type constant.
      */
-    private function getCoreTypeForDbType($infoSchemaRow)
+    private function getCoreTypeForDbType(array $infoSchemaRow): ?DataType
     {
-        if ($infoSchemaRow["data_type"] == "NUMBER" && $infoSchemaRow["data_precision"] == 19) {
-            return DataType::STR_TYPE_LONG;
-        } elseif ($infoSchemaRow["data_type"] == "NUMBER" && $infoSchemaRow["data_precision"] == 19) {
-            return DataType::STR_TYPE_LONG;
-        } elseif ($infoSchemaRow["data_type"] == "FLOAT" && $infoSchemaRow["data_precision"] == 24) {
-            return DataType::STR_TYPE_DOUBLE;
-        } elseif ($infoSchemaRow["data_type"] == "VARCHAR2") {
-            if ($infoSchemaRow["data_length"] == "10") {
-                return DataType::STR_TYPE_CHAR10;
-            } elseif ($infoSchemaRow["data_length"] == "20") {
-                return DataType::STR_TYPE_CHAR20;
-            } elseif ($infoSchemaRow["data_length"] == "100") {
-                return DataType::STR_TYPE_CHAR100;
-            } elseif ($infoSchemaRow["data_length"] == "254") {
-                return DataType::STR_TYPE_CHAR254;
-            } elseif ($infoSchemaRow["data_length"] == "280") {
-                return DataType::STR_TYPE_CHAR254;
-            } elseif ($infoSchemaRow["data_length"] == "500") {
-                return DataType::STR_TYPE_CHAR500;
-            } elseif ($infoSchemaRow["data_length"] == "4000") {
-                return DataType::STR_TYPE_TEXT;
-            } elseif ($infoSchemaRow["data_length"] == "32767") {
-                return DataType::STR_TYPE_TEXT;
-            }
-        } elseif ($infoSchemaRow["data_type"] == "CLOB") {
-            return DataType::STR_TYPE_LONGTEXT;
+        if ($infoSchemaRow['data_type'] === 'NUMBER' && $infoSchemaRow['data_precision'] == 19) {
+            return DataType::BIGINT;
         }
+
+        if ($infoSchemaRow['data_type'] === 'FLOAT' && $infoSchemaRow['data_precision'] == 24) {
+            return DataType::FLOAT;
+        }
+
+        if ($infoSchemaRow['data_type'] === 'VARCHAR2') {
+            if ($infoSchemaRow['data_length'] == '10') {
+                return DataType::CHAR10;
+            }
+
+            if ($infoSchemaRow['data_length'] == '20') {
+                return DataType::CHAR20;
+            }
+
+            if ($infoSchemaRow['data_length'] == '100') {
+                return DataType::CHAR100;
+            }
+
+            if ($infoSchemaRow['data_length'] == '254') {
+                return DataType::CHAR254;
+            }
+
+            if ($infoSchemaRow['data_length'] == '280') {
+                return DataType::CHAR254;
+            }
+
+            if ($infoSchemaRow['data_length'] == '500') {
+                return DataType::CHAR500;
+            }
+
+            if ($infoSchemaRow['data_length'] == '4000') {
+                return DataType::TEXT;
+            }
+
+            if ($infoSchemaRow['data_length'] == '32767') {
+                return DataType::TEXT;
+            }
+        } elseif ($infoSchemaRow['data_type'] === 'CLOB') {
+            return DataType::LONGTEXT;
+        }
+
         return null;
     }
 
     /**
      * @inheritDoc
      */
-    public function getDatatype($strType)
+    public function getDatatype(DataType $type): string
     {
-        $strReturn = "";
-
-        if ($strType == DataType::STR_TYPE_INT) {
-            $strReturn .= " NUMBER(19, 0) ";
-        } elseif ($strType == DataType::STR_TYPE_LONG) {
-            $strReturn .= " NUMBER(19, 0) ";
-        } elseif ($strType == DataType::STR_TYPE_DOUBLE) {
-            $strReturn .= " FLOAT (24) ";
-        } elseif ($strType == DataType::STR_TYPE_CHAR10) {
-            $strReturn .= " VARCHAR2( 10 ) ";
-        } elseif ($strType == DataType::STR_TYPE_CHAR20) {
-            $strReturn .= " VARCHAR2( 20 ) ";
-        } elseif ($strType == DataType::STR_TYPE_CHAR100) {
-            $strReturn .= " VARCHAR2( 100 ) ";
-        } elseif ($strType == DataType::STR_TYPE_CHAR254) {
-            $strReturn .= " VARCHAR2( 280 ) ";
-        } elseif ($strType == DataType::STR_TYPE_CHAR500) {
-            $strReturn .= " VARCHAR2( 500 ) ";
-        } elseif ($strType == DataType::STR_TYPE_TEXT) {
-            $strReturn .= " VARCHAR2( 32767 ) ";
-        } elseif ($strType == DataType::STR_TYPE_LONGTEXT) {
-            $strReturn .= " CLOB ";
-        } else {
-            $strReturn .= " VARCHAR2( 280 ) ";
-        }
-
-        return $strReturn;
+        return match ($type) {
+            DataType::INT, DataType::BIGINT => ' NUMBER(19, 0) ',
+            DataType::FLOAT => ' FLOAT (24) ',
+            DataType::CHAR10 => ' VARCHAR2( 10 ) ',
+            DataType::CHAR20 => ' VARCHAR2( 20 ) ',
+            DataType::CHAR100 => ' VARCHAR2( 100 ) ',
+            DataType::CHAR500 => ' VARCHAR2( 500 ) ',
+            DataType::TEXT => ' VARCHAR2( 32767 ) ',
+            DataType::LONGTEXT => ' CLOB ',
+            default => ' VARCHAR2( 280 ) ',
+        };
     }
 
     /**
      * @inheritDoc
+     * @throws QueryException
      */
-    public function changeColumn($strTable, $strOldColumnName, $strNewColumnName, $strNewDatatype)
-    {
-        if ($strOldColumnName != $strNewColumnName) {
-            $bitReturn = $this->_pQuery("ALTER TABLE ".($this->encloseTableName($strTable))." RENAME COLUMN ".($this->encloseColumnName($strOldColumnName)." TO ".$this->encloseColumnName($strNewColumnName)), array());
+    public function changeColumn(
+        string $table,
+        string $oldColumnName,
+        string $newColumnName,
+        DataType $newDataType,
+    ): bool {
+        $enclosedTableName = $this->encloseTableName($table);
+        $enclosedNewColumnName = $this->encloseColumnName($newColumnName);
+
+        if ($oldColumnName !== $newColumnName) {
+            $enclosedOldColumnName = $this->encloseColumnName($oldColumnName);
+
+            $bitReturn = $this->_pQuery(
+                "ALTER TABLE $enclosedTableName RENAME COLUMN $enclosedOldColumnName TO $enclosedNewColumnName",
+                [],
+            );
         } else {
             $bitReturn = true;
         }
 
-        return $bitReturn && $this->_pQuery("ALTER TABLE ".$this->encloseTableName($strTable)." MODIFY ( ".$this->encloseColumnName($strNewColumnName)." ".$this->getDatatype($strNewDatatype)." )", array());
+        $mappedDataType = $this->getDatatype($newDataType);
+
+        return $bitReturn && $this->_pQuery(
+                "ALTER TABLE $enclosedTableName MODIFY ( $enclosedNewColumnName $mappedDataType )",
+                [],
+            );
     }
 
     /**
      * @inheritDoc
+     * @throws QueryException
      */
-    public function addColumn($strTable, $strColumn, $strDatatype, $bitNull = null, $strDefault = null)
+    public function addColumn(string $table, string $column, DataType $dataType, bool $nullable = null, string $default = null): bool
     {
-        $strQuery = "ALTER TABLE ".($this->encloseTableName($strTable))." ADD ".($this->encloseColumnName($strColumn)." ".$this->getDatatype($strDatatype));
+        $enclosedTableName = $this->encloseTableName($table);
+        $enclosedColumnName = $this->encloseColumnName($column);
+        $mappedDataType = $this->getDatatype($dataType);
 
-        if ($strDefault !== null) {
-            $strQuery .= " DEFAULT ".$strDefault;
+        $query = "ALTER TABLE $enclosedTableName ADD $enclosedColumnName $mappedDataType";
+
+        if ($default !== null) {
+            $query .= " DEFAULT $default";
         }
 
-        if ($bitNull !== null) {
-            $strQuery .= $bitNull ? " NULL" : " NOT NULL";
+        if ($nullable !== null) {
+            $query .= $nullable ? ' NULL' : ' NOT NULL';
         }
 
-        return $this->_pQuery($strQuery, array());
+        return $this->_pQuery($query, []);
     }
 
     /**
      * @inheritDoc
+     * @throws QueryException
      */
-    public function createTable($strName, $arrFields, $arrKeys)
+    public function createTable(string $name, array $columns, array $primaryKeys): bool
     {
-        $strQuery = "";
+        $query = "CREATE TABLE $name ( \n";
 
-        //build the oracle code
-        $strQuery .= "CREATE TABLE ".$strName." ( \n";
+        // loop the fields
+        foreach ($columns as $fieldName => $columnSettings) {
+            $query .= " $fieldName ";
 
-        //loop the fields
-        foreach ($arrFields as $strFieldName => $arrColumnSettings) {
-            $strQuery .= " ".$strFieldName." ";
+            $query .= $this->getDatatype($columnSettings[0]);
 
-            $strQuery .= $this->getDatatype($arrColumnSettings[0]);
-
-            //any default?
-            if (isset($arrColumnSettings[2])) {
-                $strQuery .= "DEFAULT ".$arrColumnSettings[2]." ";
+            // any default?
+            if (isset($columnSettings[2])) {
+                $query .= 'DEFAULT ' . $columnSettings[2] . ' ';
             }
 
-            //nullable?
-            if ($arrColumnSettings[1] === true) {
-                $strQuery .= " NULL ";
+            // nullable?
+            if ($columnSettings[1] === true) {
+                $query .= ' NULL ';
             } else {
-                $strQuery .= " NOT NULL ";
+                $query .= ' NOT NULL ';
             }
 
-            $strQuery .= " , \n";
-
+            $query .= " , \n";
         }
 
-        //primary keys
-        $strQuery .= " CONSTRAINT pk_".uniqid()." primary key ( ".implode(" , ", $arrKeys)." ) \n";
-        $strQuery .= ") ";
-        $strQuery .= "DEFAULT COLLATION BINARY_CI ";
+        // primary keys
+        $query .= ' CONSTRAINT pk_' . uniqid() . ' primary key ( ' . implode(' , ', $primaryKeys) . " ) \n";
+        $query .= ') ';
+        $query .= 'DEFAULT COLLATION BINARY_CI ';
 
-        return $this->_pQuery($strQuery, array());
+        return $this->_pQuery($query, []);
     }
 
     /**
      * @inheritdoc
+     * @throws QueryException
      */
-    public function hasIndex($strTable, $strName): bool
+    public function hasIndex($table, $name): bool
     {
-        $arrIndex = iterator_to_array($this->getPArray("SELECT INDEX_NAME FROM USER_INDEXES WHERE TABLE_NAME = ? AND INDEX_NAME = ?", [strtoupper($strTable), strtoupper($strName)]), false);
+        $arrIndex = iterator_to_array(
+            $this->getPArray(
+                'SELECT INDEX_NAME FROM USER_INDEXES WHERE TABLE_NAME = ? AND INDEX_NAME = ?',
+                [strtoupper($table), strtoupper($name)],
+            ),
+            false,
+        );
+
         return count($arrIndex) > 0;
     }
 
     /**
      * @inheritdoc
+     * @throws QueryException
      */
     public function hasColumn(string $tableName, string $columnName): bool
     {
-        $columnInfo = $this->getPArray("SELECT column_name FROM user_tab_columns WHERE table_name = ? AND column_name = ?", [strtoupper($tableName), strtoupper($columnName)]);
+        $columnInfo = $this->getPArray(
+            'SELECT column_name FROM user_tab_columns WHERE table_name = ? AND column_name = ?',
+            [strtoupper($tableName), strtoupper($columnName)],
+        );
+
         return !empty($columnInfo);
     }
 
     /**
      * @inheritDoc
      */
-    public function transactionBegin()
+    public function beginTransaction(): void
     {
-        $this->bitTxOpen = true;
+        $this->txOpen = true;
     }
 
     /**
      * @inheritDoc
      */
-    public function transactionCommit()
+    public function commitTransaction(): void
     {
         oci_commit($this->linkDB);
-        $this->bitTxOpen = false;
+        $this->txOpen = false;
     }
 
     /**
      * @inheritDoc
      */
-    public function transactionRollback()
+    public function rollbackTransaction(): void
     {
         oci_rollback($this->linkDB);
-        $this->bitTxOpen = false;
+        $this->txOpen = false;
     }
 
     /**
      * @inheritDoc
+     * @throws QueryException
      */
-    public function getDbInfo()
+    public function getDbInfo(): array
     {
-        $contextSort = iterator_to_array($this->getPArray("select sys_context ('userenv', 'nls_sort') val1 from sys.dual", []), false);
-        $contextComp = iterator_to_array($this->getPArray("select sys_context ('userenv', 'nls_comp') val1 from sys.dual", []), false);
+        $contextSort = iterator_to_array(
+            $this->getPArray("select sys_context ('userenv', 'nls_sort') val1 from sys.dual", []),
+            false,
+        );
+        $contextComp = iterator_to_array(
+            $this->getPArray("select sys_context ('userenv', 'nls_comp') val1 from sys.dual", []),
+            false,
+        );
 
-        $arrReturn = [];
-        $arrReturn["version"] = $this->getServerVersion();
-        $arrReturn["dbserver"] = oci_server_version($this->linkDB);
-        $arrReturn["dbclient"] = function_exists("oci_client_version") ? oci_client_version() : "";
-        $arrReturn["nls_sort"] = $contextSort[0]["val1"] ?? '-';
-        $arrReturn["nls_comp"] = $contextComp[0]["val1"] ?? '-';
-        return $arrReturn;
+        return [
+            'version' => $this->getServerVersion(),
+            'dbserver' => oci_server_version($this->linkDB),
+            'dbclient' => function_exists('oci_client_version') ? oci_client_version() : '',
+            'nls_sort' => $contextSort[0]['val1'] ?? '-',
+            'nls_comp' => $contextComp[0]['val1'] ?? '-',
+        ];
     }
 
-
     /**
-     * parses the version out of the server info string.
+     * Parses the version out of the server info string.
      * @see https://github.com/doctrine/dbal/blob/master/lib/Doctrine/DBAL/Driver/OCI8/OCI8Connection.php
-     * @return string
      */
-    private function getServerVersion()
+    private function getServerVersion(): string
     {
-        if (! preg_match('/\s+(\d+\.\d+\.\d+\.\d+\.\d+)\s+/', oci_server_version($this->linkDB), $version)) {
-            throw new \UnexpectedValueException(oci_server_version($this->linkDB));
+        if (!preg_match('/\s+(\d+\.\d+\.\d+\.\d+\.\d+)\s+/', oci_server_version($this->linkDB), $version)) {
+            throw new UnexpectedValueException(oci_server_version($this->linkDB));
         }
+
         return $version[1];
     }
 
     /**
      * @inheritdoc
      */
-    public function handlesDumpCompression()
+    public function handlesDumpCompression(): bool
     {
         return false;
     }
@@ -546,12 +619,13 @@ class Oci8Driver extends DriverAbstract
     /**
      * @inheritDoc
      */
-    public function dbExport(&$strFilename, $arrTables)
+    public function dbExport(string &$fileName, array $tables): bool
     {
-        $strTables = implode(",", $arrTables);
+        $tablesString = implode(',', $tables);
 
-        $dumpBin = (new ExecutableFinder())->find($this->strDumpBin);
-        $strCommand = $dumpBin." ".$this->objCfg->getUsername()."/".$this->objCfg->getPassword()." CONSISTENT=n TABLES=".$strTables." FILE='".$strFilename."'";
+        $dumpBin = (new ExecutableFinder())->find($this->dumpBin);
+        $strCommand = $dumpBin . ' ' . $this->config->getUsername() . '/' . $this->config->getPassword(
+            ) . ' CONSISTENT=n TABLES=' . $tablesString . " FILE='" . $fileName . "'";
 
         $this->runCommand($strCommand);
 
@@ -561,12 +635,13 @@ class Oci8Driver extends DriverAbstract
     /**
      * @inheritDoc
      */
-    public function dbImport($strFilename)
+    public function dbImport($fileName): bool
     {
-        $restoreBin = (new ExecutableFinder())->find($this->strRestoreBin);
-        $strCommand = $restoreBin." ".$this->objCfg->getUsername()."/".$this->objCfg->getPassword()." FILE='".$strFilename."'";
+        $restoreBin = (new ExecutableFinder())->find($this->restoreBin);
+        $command = $restoreBin . ' ' . $this->config->getUsername() . '/' . $this->config->getPassword(
+            ) . " FILE='" . $fileName . "'";
 
-        $this->runCommand($strCommand);
+        $this->runCommand($command);
 
         return true;
     }
@@ -574,151 +649,137 @@ class Oci8Driver extends DriverAbstract
     /**
      * Transforms the prepared statement into a valid oracle syntax.
      * This is done by replying the ?-chars by :x entries.
-     *
-     * @param string $strQuery
-     *
-     * @return string
      */
-    private function processQuery($strQuery, $params = null)
+    private function processQuery(string $query): string
     {
-        $strQuery = preg_replace_callback('/\?/', static function($value): string {
+        return preg_replace_callback('/\?/', static function (): string {
             static $i = 0;
             $i++;
             return ':' . $i;
-        }, $strQuery);
-
-        return $strQuery;
+        }, $query);
     }
 
     /**
      * Does as cache-lookup for prepared statements.
      * Reduces the number of recompiles at the db-side.
      *
-     * @param string $strQuery
-     *
-     * @return resource
-     * @since 3.4
+     * @return resource | false
      */
-    private function getParsedStatement($strQuery)
+    private function getParsedStatement(string $query)
     {
-
-        if (stripos($strQuery, "select") !== false) {
-            $strQuery = str_replace(array(" as ", " AS "), array(" ", " "), $strQuery);
+        if (stripos($query, 'select') !== false) {
+            $query = str_replace([' as ', ' AS '], [' ', ' '], $query);
         }
 
-        $objStatement = oci_parse($this->linkDB, $strQuery);
-        return $objStatement;
+        return oci_parse($this->linkDB, $query);
     }
 
     /**
-     * converts a result-row. changes all keys to lower-case keys again
-     *
-     * @param array $arrRow
-     * @return array
+     * Converts a result-row. Changes all keys to lower-case keys again.
      */
-    private function parseResultRow(array $arrRow)
+    private function parseResultRow(array $row): array
     {
-        $arrRow = array_change_key_case($arrRow, CASE_LOWER);
-        if (isset($arrRow["count(*)"])) {
-            $arrRow["COUNT(*)"] = $arrRow["count(*)"];
+        $row = array_change_key_case($row);
+        if (isset($row['count(*)'])) {
+            $row['COUNT(*)'] = $row['count(*)'];
         }
 
-        foreach ($arrRow as $key => $val) {
-            if (is_object($val) && get_class($val) == "OCILob") {
-                //inject an anonymous lazy loader
-                $arrRow[$key] = new class($val)   {
-                    private $val;
+        foreach ($row as $key => $val) {
+            if (is_object($val) && get_class($val) === 'OCILob') {
+                // Inject an anonymous lazy loader
+                $row[$key] = new class($val) implements \Stringable {
+                    private \OCILob $val;
 
-                    public function __construct($val)
+                    public function __construct(\OCILob $val)
                     {
                         $this->val = $val;
                     }
 
-                    public function __toString()
+                    public function __toString(): string
                     {
-                        return (string)$this->val->load();
+                        return (string) $this->val->load();
                     }
                 };
             }
         }
 
-        return $arrRow;
+        return $row;
     }
 
     /**
      * @inheritDoc
      */
-    public function flushQueryCache()
+    public function flushQueryCache(): void
     {
     }
 
 
-    /** @var bool caching the version parse & compare  */
-    private static $is12c = null;
+    /** @var bool caching the version parse & compare */
+    private static bool $is12c = false;
 
     /**
      * @inheritdoc
      */
-    public function appendLimitExpression($strQuery, $intStart, $intEnd)
+    public function appendLimitExpression(string $query, int $start, int $end): string
     {
-
         if (self::$is12c === null) {
-            self::$is12c = version_compare($this->getServerVersion(), "12.1", "ge");
+            self::$is12c = version_compare($this->getServerVersion(), '12.1', 'ge');
         }
 
         if (self::$is12c) {
-            //TODO: 12c has a new offset syntax - lets see if it's really faster
-            $intDelta = $intEnd - $intStart + 1;
-            return $strQuery . " OFFSET {$intStart} ROWS FETCH NEXT {$intDelta} ROWS ONLY";
+            // TODO: 12c has a new offset syntax - lets see if it's really faster
+            $intDelta = $end - $start + 1;
+            return $query . " OFFSET $start ROWS FETCH NEXT $intDelta ROWS ONLY";
         }
 
-        $intStart++;
-        $intEnd++;
+        $start++;
+        $end++;
 
-        return "SELECT * FROM (
+        return 'SELECT * FROM (
                      SELECT a.*, ROWNUM rnum FROM
-                        ( ".$strQuery.") a
-                     WHERE ROWNUM <= ".$intEnd."
+                        ( ' . $query . ') a
+                     WHERE ROWNUM <= ' . $end . '
                 )
-                WHERE rnum >= ".$intStart;
+                WHERE rnum >= ' . $start;
     }
 
     /**
      * @inheritdoc
      */
-    public function getConcatExpression(array $parts)
+    public function getConcatExpression(array $parts): string
     {
-        return implode(" || ", $parts);
+        return implode(' || ', $parts);
     }
 
     /**
      * @inheritDoc
      */
-    public function convertToDatabaseValue($value, string $type)
+    public function convertToDatabaseValue(mixed $value, DataType $type): mixed
     {
-        if ($type === DataType::STR_TYPE_TEXT) {
-            return mb_substr($value, 0, 4000);
-        } else {
-            return parent::convertToDatabaseValue($value, $type);
-        }
+        return match ($type) {
+            DataType::TEXT => mb_substr($value, 0, 4000),
+            default => parent::convertToDatabaseValue($value, $type),
+        };
     }
 
     /**
      * Sets the sorting and comparison of strings to case insensitive
+     * @throws QueryException
      */
-    private function setCaseInsensitiveSort()
+    private function setCaseInsensitiveSort(): void
     {
-        $this->_pQuery("alter session set nls_sort=binary_ci", array());
-        $this->_pQuery("alter session set nls_comp=LINGUISTIC", array());
+        $this->_pQuery('alter session set nls_sort=binary_ci', []);
+        $this->_pQuery('alter session set nls_comp=LINGUISTIC', []);
     }
 
     /**
      * Sets the sorting and comparison of strings to case sensitive
+     * @throws QueryException
      */
-    private function setCaseSensitiveSort()
+    private function setCaseSensitiveSort(): void
     {
-        $this->_pQuery("alter session set nls_sort=binary", array());
-        $this->_pQuery("alter session set nls_comp=ANSI", array());
+        $this->_pQuery('alter session set nls_sort=binary', []);
+        $this->_pQuery('alter session set nls_comp=ANSI', []);
     }
 
     public function getSubstringExpression(string $value, int $offset, ?int $length): string

--- a/src/Driver/PostgresDriver.php
+++ b/src/Driver/PostgresDriver.php
@@ -21,57 +21,58 @@ use Artemeon\Database\Schema\Table;
 use Artemeon\Database\Schema\TableColumn;
 use Artemeon\Database\Schema\TableIndex;
 use Artemeon\Database\Schema\TableKey;
+use Generator;
+use PgSql\Connection;
 use Symfony\Component\Process\ExecutableFinder;
 
 /**
- * db-driver for postgres using the php-postgres-interface
- *
- * @package module_system
- * @author sidler@mulchprod.de
+ * DB-driver for postgres using the php-postgres-interface.
  */
 class PostgresDriver extends DriverAbstract
 {
+    private Connection | false | null $linkDB;
 
-    private $linkDB; //DB-Link
+    private ?ConnectionParameters $config = null;
 
-    /** @var ConnectionParameters */
-    private $objCfg = null;
+    private string $dumpBin = 'pg_dump'; // Binary to dump db (if not in path, add the path here)
+    private string $restoreBin = 'psql'; // Binary to restore db (if not in path, add the path here)
 
-    private $strDumpBin = "pg_dump"; //Binary to dump db (if not in path, add the path here)
-    private $strRestoreBin = "psql"; //Binary to restore db (if not in path, add the path here)
-
-    private $arrCxInfo = array();
+    private array $cxInfo = [];
 
     /**
      * @inheritdoc
+     * @throws QueryException
      */
-    public function dbconnect(ConnectionParameters $objParams)
+    public function dbconnect(ConnectionParameters $params): bool
     {
-        $port = $objParams->getPort();
+        $port = $params->getPort();
         if (empty($port)) {
             $port = 5432;
         }
 
-        $this->objCfg = $objParams;
-        $this->linkDB = pg_connect("host='".$objParams->getHost()."' port='".$port."' dbname='".$objParams->getDatabase()."' user='".$objParams->getUsername()."' password='".$objParams->getPassword()."'");
+        $this->config = $params;
+        $this->linkDB = pg_connect(
+            "host='" . $params->getHost() . "' port='" . $port . "' dbname='" . $params->getDatabase(
+            ) . "' user='" . $params->getUsername() . "' password='" . $params->getPassword() . "'"
+        );
 
         if (!$this->linkDB) {
-            throw new ConnectionException("Error connecting to database: " . pg_last_error());
+            throw new ConnectionException('Error connecting to database: ' . pg_last_error());
         }
 
-        $this->_pQuery("SET client_encoding='UTF8'", array());
+        $this->_pQuery("SET client_encoding='UTF8'", []);
 
-        $this->arrCxInfo = pg_version($this->linkDB);
+        $this->cxInfo = pg_version($this->linkDB);
+
         return true;
-
     }
 
     /**
      * @inheritDoc
      */
-    public function dbclose()
+    public function dbclose(): void
     {
-        if ($this->linkDB !== null && is_resource($this->linkDB)) {
+        if (is_resource($this->linkDB)) {
             pg_close($this->linkDB);
             $this->linkDB = null;
         }
@@ -79,22 +80,23 @@ class PostgresDriver extends DriverAbstract
 
     /**
      * @inheritDoc
+     * @throws QueryException
      */
-    public function _pQuery($strQuery, $arrParams)
+    public function _pQuery(string $query, array $params): bool
     {
-        $strQuery = $this->processQuery($strQuery);
+        $query = $this->processQuery($query);
 
-        $strName = $this->getPreparedStatementName($strQuery);
-        if ($strName === false) {
-            throw new QueryException('Could not prepare statement: ' . $this->getError(), $strQuery, $arrParams);
+        $name = $this->getPreparedStatementName($query);
+        if ($name === false) {
+            throw new QueryException('Could not prepare statement: ' . $this->getError(), $query, $params);
         }
 
-        $objResult = pg_execute($this->linkDB, $strName, $arrParams);
-        if ($objResult === false) {
-            throw new QueryException('Could not execute statement: ' . $this->getError(), $strQuery, $arrParams);
+        $result = pg_execute($this->linkDB, $name, $params);
+        if ($result === false) {
+            throw new QueryException('Could not execute statement: ' . $this->getError(), $query, $params);
         }
 
-        $this->intAffectedRows = pg_affected_rows($objResult);
+        $this->affectedRowsCount = pg_affected_rows($result);
 
         return true;
     }
@@ -102,118 +104,140 @@ class PostgresDriver extends DriverAbstract
     /**
      * @inheritDoc
      */
-    public function getPArray($strQuery, $arrParams): \Generator
+    public function getPArray($query, $params): Generator
     {
-        $strQuery = $this->processQuery($strQuery);
-        $strName = $this->getPreparedStatementName($strQuery);
-        if ($strName === false) {
-            throw new QueryException('Could not prepare statement: ' . $this->getError(), $strQuery, $arrParams);
+        $query = $this->processQuery($query);
+        $name = $this->getPreparedStatementName($query);
+        if ($name === false) {
+            throw new QueryException('Could not prepare statement: ' . $this->getError(), $query, $params);
         }
 
-        $resultSet = pg_execute($this->linkDB, $strName, $arrParams);
+        $resultSet = pg_execute($this->linkDB, $name, $params);
 
         if ($resultSet === false) {
-            throw new QueryException('Could not execute statement: ' . $this->getError(), $strQuery, $arrParams);
+            throw new QueryException('Could not execute statement: ' . $this->getError(), $query, $params);
         }
 
-        while ($arrRow = pg_fetch_array($resultSet, null, PGSQL_ASSOC)) {
+        while ($row = pg_fetch_array($resultSet, null, PGSQL_ASSOC)) {
             //conversions to remain compatible:
             //   count --> COUNT(*)
-            if (isset($arrRow["count"])) {
-                $arrRow["COUNT(*)"] = $arrRow["count"];
+            if (isset($row['count'])) {
+                $row['COUNT(*)'] = $row['count'];
             }
 
-            yield $arrRow;
+            yield $row;
         }
 
         pg_free_result($resultSet);
     }
 
     /**
-     * Postgres supports UPSERTS since 9.5, see http://michael.otacoo.com/postgresql-2/postgres-9-5-feature-highlight-upsert/.
+     * Postgres supports UPSERTS since 9.5 ({@see http://michael.otacoo.com/postgresql-2/postgres-9-5-feature-highlight-upsert/}).
      * A fallback is the base select / update method.
      *
      * @inheritDoc
      */
-    public function insertOrUpdate($strTable, $arrColumns, $arrValues, $arrPrimaryColumns)
+    public function insertOrUpdate(string $table, array $columns, array $values, array $primaryColumns): bool
     {
-
-        //get the current postgres version to validate the upsert features
-        if (version_compare($this->arrCxInfo["server"], "9.5", "<")) {
-            //base implementation
-            return parent::insertOrUpdate($strTable, $arrColumns, $arrValues, $arrPrimaryColumns);
+        // get the current postgres version to validate the upsert features
+        if (version_compare($this->cxInfo['server'], '9.5', '<')) {
+            // base implementation
+            return parent::insertOrUpdate($table, $columns, $values, $primaryColumns);
         }
 
-        $arrPlaceholder = array();
-        $arrMappedColumns = array();
-        $arrKeyValuePairs = array();
+        $placeholders = [];
+        $mappedColumns = [];
+        $keyValuePairs = [];
 
-        foreach ($arrColumns as $intI => $strOneCol) {
-            $arrPlaceholder[] = "?";
-            $arrMappedColumns[] = $this->encloseColumnName($strOneCol);
+        foreach ($columns as $i => $column) {
+            $placeholders[] = '?';
+            $mappedColumns[] = $this->encloseColumnName($column);
 
-            if (!in_array($strOneCol, $arrPrimaryColumns)) {
-                $arrKeyValuePairs[] = $this->encloseColumnName($strOneCol)." = ?";
-                $arrValues[] = $arrValues[$intI];
+            if (!in_array($column, $primaryColumns, true)) {
+                $keyValuePairs[] = $this->encloseColumnName($column) . ' = ?';
+                $values[] = $values[$i];
             }
         }
 
-        if (empty($arrKeyValuePairs)) {
-            $strQuery = "INSERT INTO ".$this->encloseTableName($strTable)." (".implode(", ", $arrMappedColumns).") VALUES (".implode(", ", $arrPlaceholder).")
-                        ON CONFLICT ON CONSTRAINT ".$strTable."_pkey DO NOTHING";
+        if (empty($keyValuePairs)) {
+            $strQuery = 'INSERT INTO ' . $this->encloseTableName($table) . ' (' . implode(
+                    ', ',
+                    $mappedColumns
+                ) . ') VALUES (' . implode(
+                    ', ',
+                    $placeholders
+                ) . ')
+                        ON CONFLICT ON CONSTRAINT ' . $table . '_pkey DO NOTHING';
         } else {
-            $strQuery = "INSERT INTO ".$this->encloseTableName($strTable)." (".implode(", ", $arrMappedColumns).") VALUES (".implode(", ", $arrPlaceholder).")
-                        ON CONFLICT ON CONSTRAINT ".$strTable."_pkey DO UPDATE SET ".implode(", ", $arrKeyValuePairs);
+            $strQuery = 'INSERT INTO ' . $this->encloseTableName($table) . ' (' . implode(
+                    ', ',
+                    $mappedColumns
+                ) . ') VALUES (' . implode(', ', $placeholders) . ')
+                        ON CONFLICT ON CONSTRAINT ' . $table . '_pkey DO UPDATE SET ' . implode(', ', $keyValuePairs);
         }
 
-        return $this->_pQuery($strQuery, $arrValues);
+        return $this->_pQuery($strQuery, $values);
     }
 
     /**
      * @inheritDoc
      */
-    public function getError()
+    public function getError(): string
     {
-        $strError = pg_last_error($this->linkDB);
-        return $strError;
+        return pg_last_error($this->linkDB);
     }
 
     /**
      * @inheritDoc
+     * @throws QueryException
      */
     public function getTables(): array
     {
-        $generator = $this->getPArray("SELECT *, table_name as name FROM information_schema.tables WHERE table_schema = 'public'", []);
+        $generator = $this->getPArray(
+            "SELECT *, table_name as name FROM information_schema.tables WHERE table_schema = 'public'",
+            []
+        );
         $result = [];
         foreach ($generator as $row) {
-            $result[] = ['name' => strtolower($row["name"])];
+            $result[] = ['name' => strtolower($row['name'])];
         }
+
         return $result;
     }
 
     /**
      * @inheritDoc
+     * @throws QueryException
      */
     public function getTableInformation(string $tableName): Table
     {
         $table = new Table($tableName);
 
         // fetch all columns
-        $columnInfo = $this->getPArray("SELECT * FROM information_schema.columns WHERE table_name = ?", [$tableName]) ?: [];
-        foreach ($columnInfo as $arrOneColumn) {
-            $col = new TableColumn($arrOneColumn["column_name"]);
-            $col->setInternalType($this->getCoreTypeForDbType($arrOneColumn));
-            $col->setDatabaseType($this->getDatatype($col->getInternalType()));
-            $col->setNullable($arrOneColumn["is_nullable"] == "YES");
-            $table->addColumn($col);
+        $columnInfo = $this->getPArray('SELECT * FROM information_schema.columns WHERE table_name = ?', [$tableName]
+        ) ?: [];
+        foreach ($columnInfo as $column) {
+            $table->addColumn(
+                TableColumn::make($column['column_name'])
+                    ->setInternalType($this->getCoreTypeForDbType($column))
+                    ->setDatabaseType($this->getDatatype($this->getCoreTypeForDbType($column)))
+                    ->setNullable($column['is_nullable'] === 'YES'),
+            );
         }
 
-        //fetch all indexes
-        $indexes = $this->getPArray("select * from pg_indexes where tablename  = ? AND indexname NOT LIKE '%_pkey'", [$tableName]) ?: [];
+        // fetch all indexes
+        $indexes = $this->getPArray(
+            "select * from pg_indexes where tablename  = ? AND indexname NOT LIKE '%_pkey'",
+            [$tableName],
+        ) ?: [];
         foreach ($indexes as $indexInfo) {
             $index = new TableIndex($indexInfo['indexname']);
             //scrape the columns from the indexdef
-            $cols = substr($indexInfo['indexdef'], strpos($indexInfo['indexdef'], "(")+1, strpos($indexInfo['indexdef'], ")")-strpos($indexInfo['indexdef'], "(")-1);
+            $cols = substr(
+                $indexInfo['indexdef'],
+                strpos($indexInfo['indexdef'], '(') + 1,
+                strpos($indexInfo['indexdef'], ')') - strpos($indexInfo['indexdef'], '(') - 1
+            );
             $index->setDescription($cols);
             $table->addIndex($index);
         }
@@ -242,204 +266,210 @@ class PostgresDriver extends DriverAbstract
         return $table;
     }
 
-
     /**
-     * Tries to convert a column provided by the database back to the Kajona internal type constant
-     * @param $infoSchemaRow
-     * @return null|string
+     * Tries to convert a column provided by the database back to the Kajona internal type constant.
      */
-    private function getCoreTypeForDbType($infoSchemaRow)
+    private function getCoreTypeForDbType(array $infoSchemaRow): ?DataType
     {
-        if ($infoSchemaRow["data_type"] == "integer") {
-            return DataType::STR_TYPE_INT;
-        } elseif ($infoSchemaRow["data_type"] == "bigint") {
-            return DataType::STR_TYPE_LONG;
-        } elseif ($infoSchemaRow["data_type"] == "numeric") {
-            return DataType::STR_TYPE_DOUBLE;
-        } elseif ($infoSchemaRow["data_type"] == "character varying") {
-            if ($infoSchemaRow["character_maximum_length"] == "10") {
-                return DataType::STR_TYPE_CHAR10;
-            } elseif ($infoSchemaRow["character_maximum_length"] == "20") {
-                return DataType::STR_TYPE_CHAR20;
-            } elseif ($infoSchemaRow["character_maximum_length"] == "100") {
-                return DataType::STR_TYPE_CHAR100;
-            } elseif ($infoSchemaRow["character_maximum_length"] == "254") {
-                return DataType::STR_TYPE_CHAR254;
-            } elseif ($infoSchemaRow["character_maximum_length"] == "500") {
-                return DataType::STR_TYPE_CHAR500;
-            }
-        } elseif ($infoSchemaRow["data_type"] == "text") {
-            return DataType::STR_TYPE_TEXT;
+        if ($infoSchemaRow['data_type'] === 'integer') {
+            return DataType::INT;
         }
+
+        if ($infoSchemaRow['data_type'] === 'bigint') {
+            return DataType::BIGINT;
+        }
+
+        if ($infoSchemaRow['data_type'] === 'numeric') {
+            return DataType::FLOAT;
+        }
+
+        if ($infoSchemaRow['data_type'] === 'character varying') {
+            if ($infoSchemaRow['character_maximum_length'] == '10') {
+                return DataType::CHAR10;
+            } elseif ($infoSchemaRow['character_maximum_length'] == '20') {
+                return DataType::CHAR20;
+            } elseif ($infoSchemaRow['character_maximum_length'] == '100') {
+                return DataType::CHAR100;
+            } elseif ($infoSchemaRow['character_maximum_length'] == '254') {
+                return DataType::CHAR254;
+            } elseif ($infoSchemaRow['character_maximum_length'] == '500') {
+                return DataType::CHAR500;
+            }
+        } elseif ($infoSchemaRow['data_type'] === 'text') {
+            return DataType::TEXT;
+        }
+
         return null;
     }
 
     /**
      * @inheritDoc
      */
-    public function getDatatype($strType)
+    public function getDatatype(DataType $type): string
     {
-        $strReturn = "";
-
-        if ($strType == DataType::STR_TYPE_INT) {
-            $strReturn .= " INT ";
-        } elseif ($strType == DataType::STR_TYPE_LONG) {
-            $strReturn .= " BIGINT ";
-        } elseif ($strType == DataType::STR_TYPE_DOUBLE) {
-            $strReturn .= " NUMERIC ";
-        } elseif ($strType == DataType::STR_TYPE_CHAR10) {
-            $strReturn .= " VARCHAR( 10 ) ";
-        } elseif ($strType == DataType::STR_TYPE_CHAR20) {
-            $strReturn .= " VARCHAR( 20 ) ";
-        } elseif ($strType == DataType::STR_TYPE_CHAR100) {
-            $strReturn .= " VARCHAR( 100 ) ";
-        } elseif ($strType == DataType::STR_TYPE_CHAR254) {
-            $strReturn .= " VARCHAR( 254 ) ";
-        } elseif ($strType == DataType::STR_TYPE_CHAR500) {
-            $strReturn .= " VARCHAR( 500 ) ";
-        } elseif ($strType == DataType::STR_TYPE_TEXT) {
-            $strReturn .= " TEXT ";
-        } elseif ($strType == DataType::STR_TYPE_LONGTEXT) {
-            $strReturn .= " TEXT ";
-        } else {
-            $strReturn .= " VARCHAR( 254 ) ";
-        }
-
-        return $strReturn;
+        return match ($type) {
+            DataType::INT => ' INT ',
+            DataType::BIGINT => ' BIGINT ',
+            DataType::FLOAT => ' NUMERIC ',
+            DataType::CHAR10 => ' VARCHAR( 10 ) ',
+            DataType::CHAR20 => ' VARCHAR( 20 ) ',
+            DataType::CHAR100 => ' VARCHAR( 100 ) ',
+            DataType::CHAR500 => ' VARCHAR( 500 ) ',
+            DataType::TEXT, DataType::LONGTEXT => ' TEXT ',
+            default => ' VARCHAR( 254 ) ',
+        };
     }
 
     /**
      * @inheritDoc
+     * @throws QueryException
      */
-    public function changeColumn($strTable, $strOldColumnName, $strNewColumnName, $strNewDatatype)
+    public function changeColumn(string $table, string $oldColumnName, string $newColumnName, DataType $newDataType): bool
     {
-        if ($strOldColumnName != $strNewColumnName) {
-            $bitReturn = $this->_pQuery("ALTER TABLE ".($this->encloseTableName($strTable))." RENAME COLUMN ".($this->encloseColumnName($strOldColumnName)." TO ".$this->encloseColumnName($strNewColumnName)), array());
+        $enclosedTableName = $this->encloseTableName($table);
+        $enclosedNewColumnName = $this->encloseColumnName($newColumnName);
+
+        if ($oldColumnName !== $newColumnName) {
+            $enclosedOldColumnName = $this->encloseColumnName($oldColumnName);
+
+            $bitReturn = $this->_pQuery(
+                "ALTER TABLE $enclosedTableName RENAME COLUMN $enclosedOldColumnName TO $enclosedNewColumnName",
+                [],
+            );
         } else {
             $bitReturn = true;
         }
 
-        return $bitReturn && $this->_pQuery("ALTER TABLE ".$this->encloseTableName($strTable)." ALTER COLUMN ".$this->encloseColumnName($strNewColumnName)." TYPE ".$this->getDatatype($strNewDatatype), array());
+        return $bitReturn && $this->_pQuery(
+                "ALTER TABLE $enclosedTableName ALTER COLUMN $enclosedNewColumnName TYPE " . $this->getDatatype($newDataType),
+                [],
+            );
     }
 
     /**
      * @inheritDoc
+     * @throws QueryException
      */
-    public function createTable($strName, $arrFields, $arrKeys)
+    public function createTable(string $name, array $columns, array $primaryKeys): bool
     {
-        $strQuery = "";
-
-        //build the mysql code
-        $strQuery .= "CREATE TABLE ".$this->encloseTableName($strName)." ( \n";
+        $query = 'CREATE TABLE ' . $this->encloseTableName($name) . " ( \n";
 
         //loop the fields
-        foreach ($arrFields as $strFieldName => $arrColumnSettings) {
-            $strQuery .= " ".$strFieldName." ";
+        foreach ($columns as $strFieldName => $arrColumnSettings) {
+            $query .= " $strFieldName ";
 
-            $strQuery .= $this->getDatatype($arrColumnSettings[0]);
+            $query .= $this->getDatatype($arrColumnSettings[0]);
 
             //any default?
             if (isset($arrColumnSettings[2])) {
-                $strQuery .= "DEFAULT ".$arrColumnSettings[2]." ";
+                $query .= 'DEFAULT ' . $arrColumnSettings[2] . ' ';
             }
 
-            //nullable?
+            // nullable?
             if ($arrColumnSettings[1] === true) {
-                $strQuery .= " NULL ";
+                $query .= ' NULL ';
             } else {
-                $strQuery .= " NOT NULL ";
+                $query .= ' NOT NULL ';
             }
 
-            $strQuery .= " , \n";
-
+            $query .= " , \n";
         }
 
-        //primary keys
-        $strQuery .= " PRIMARY KEY ( ".implode(" , ", $arrKeys)." ) \n";
-        $strQuery .= ") ";
+        // primary keys
+        $query .= ' PRIMARY KEY ( ' . implode(' , ', $primaryKeys) . " ) \n";
+        $query .= ') ';
 
-        return $this->_pQuery($strQuery, array());
+        return $this->_pQuery($query, []);
     }
 
     /**
      * @inheritdoc
+     * @throws QueryException
      */
-    public function hasIndex($strTable, $strName): bool
+    public function hasIndex($table, $name): bool
     {
-        $arrIndex = iterator_to_array($this->getPArray("SELECT indexname FROM pg_indexes WHERE tablename = ? AND indexname = ?", [$strTable, $strName]), false);
+        $arrIndex = iterator_to_array(
+            $this->getPArray('SELECT indexname FROM pg_indexes WHERE tablename = ? AND indexname = ?', [$table, $name]),
+            false
+        );
+
         return count($arrIndex) > 0;
     }
 
     /**
      * @inheritDoc
+     * @throws QueryException
      */
-    public function transactionBegin()
+    public function beginTransaction(): void
     {
-        $strQuery = "BEGIN";
-        $this->_pQuery($strQuery, array());
+        $strQuery = 'BEGIN';
+        $this->_pQuery($strQuery, []);
+    }
+
+    /**
+     * @inheritDoc
+     * @throws QueryException
+     */
+    public function commitTransaction(): void
+    {
+        $str_pQuery = 'COMMIT';
+        $this->_pQuery($str_pQuery, []);
+    }
+
+    /**
+     * @inheritDoc
+     * @throws QueryException
+     */
+    public function rollbackTransaction(): void
+    {
+        $strQuery = 'ROLLBACK';
+        $this->_pQuery($strQuery, []);
     }
 
     /**
      * @inheritDoc
      */
-    public function transactionCommit()
-    {
-        $str_pQuery = "COMMIT";
-        $this->_pQuery($str_pQuery, array());
-    }
-
-    /**
-     * @inheritDoc
-     */
-    public function transactionRollback()
-    {
-        $strQuery = "ROLLBACK";
-        $this->_pQuery($strQuery, array());
-    }
-
-    /**
-     * @inheritDoc
-     */
-    public function getDbInfo()
+    public function getDbInfo(): array
     {
         return pg_version($this->linkDB);
     }
-
-
 
     //--- DUMP & RESTORE ------------------------------------------------------------------------------------
 
     /**
      * @inheritDoc
      */
-    public function dbExport(&$strFilename, $arrTables)
+    public function dbExport(string &$fileName, array $tables): bool
     {
-        $strTables = "-t ".implode(" -t ", $arrTables);
+        $tablesString = '-t ' . implode(' -t ', $tables);
 
-        $strCommand = '';
-        if ($this->objCfg->getPassword() != "") {
+        $command = '';
+        if ($this->config->getPassword() !== '') {
             if ($this->isWinOs()) {
-                $strCommand .= "SET \"PGPASSWORD=".$this->objCfg->getPassword()."\" && ";
+                $command .= "SET \"PGPASSWORD=" . $this->config->getPassword() . "\" && ";
             } else {
-                $strCommand .= "PGPASSWORD=\"".$this->objCfg->getPassword()."\" ";
+                $command .= "PGPASSWORD=\"" . $this->config->getPassword() . "\" ";
             }
         }
 
-        $port = $this->objCfg->getPort();
+        $port = $this->config->getPort();
         if (empty($port)) {
             $port = 5432;
         }
 
-        $dumpBin = (new ExecutableFinder())->find($this->strDumpBin);
+        $dumpBin = (new ExecutableFinder())->find($this->dumpBin);
+        $host = $this->config->getHost();
+        $username = $this->config->getUsername();
+        $database = $this->config->getDatabase();
 
         if ($this->handlesDumpCompression()) {
-            $strFilename .= ".gz";
-            $strCommand .= $dumpBin." --clean --no-owner -h".$this->objCfg->getHost().($this->objCfg->getUsername() != "" ? " -U".$this->objCfg->getUsername() : "")." -p".$port." ".$strTables." ".$this->objCfg->getDatabase()." | gzip > \"".$strFilename."\"";
+            $fileName .= '.gz';
+            $command .= $dumpBin . ' --clean --no-owner -h' . $host . ($username !== '' ? ' -U' . $username : '') . ' -p' . $port . ' ' . $tablesString . ' ' . $database . " | gzip > \"" . $fileName . "\"";
         } else {
-            $strCommand .= $dumpBin." --clean --no-owner -h".$this->objCfg->getHost().($this->objCfg->getUsername() != "" ? " -U".$this->objCfg->getUsername() : "")." -p".$port." ".$strTables." ".$this->objCfg->getDatabase()." > \"".$strFilename."\"";
+            $command .= $dumpBin . ' --clean --no-owner -h' . $host . ($username !== '' ? ' -U' . $username : '') . ' -p' . $port . ' ' . $tablesString . ' ' . $database . " > \"" . $fileName . "\"";
         }
 
-        $this->runCommand($strCommand);
+        $this->runCommand($command);
 
         return true;
     }
@@ -447,107 +477,101 @@ class PostgresDriver extends DriverAbstract
     /**
      * @inheritDoc
      */
-    public function dbImport($strFilename)
+    public function dbImport($fileName): bool
     {
-        $strCommand= '';
-        if ($this->objCfg->getPassword() != "") {
+        $command = '';
+        if ($this->config->getPassword() !== '') {
             if ($this->isWinOs()) {
-                $strCommand .= "SET \"PGPASSWORD=".$this->objCfg->getPassword()."\" && ";
+                $command .= "SET \"PGPASSWORD=" . $this->config->getPassword() . "\" && ";
             } else {
-                $strCommand .= "PGPASSWORD=\"".$this->objCfg->getPassword()."\" ";
+                $command .= "PGPASSWORD=\"" . $this->config->getPassword() . "\" ";
             }
         }
 
-        $port = $this->objCfg->getPort();
+        $port = $this->config->getPort();
         if (empty($port)) {
             $port = 5432;
         }
 
-        $restoreBin = (new ExecutableFinder())->find($this->strRestoreBin);
+        $restoreBin = (new ExecutableFinder())->find($this->restoreBin);
+        $host = $this->config->getHost();
+        $username = $this->config->getUsername();
+        $database = $this->config->getDatabase();
 
-        if ($this->handlesDumpCompression() && pathinfo($strFilename, PATHINFO_EXTENSION) === 'gz') {
-            $strCommand .= " gunzip -c \"".$strFilename."\" | ".$restoreBin." -q -h".$this->objCfg->getHost().($this->objCfg->getUsername() != "" ? " -U".$this->objCfg->getUsername() : "")." -p".$port." ".$this->objCfg->getDatabase()."";
+        if ($this->handlesDumpCompression() && pathinfo($fileName, PATHINFO_EXTENSION) === 'gz') {
+            $command .= " gunzip -c \"" . $fileName . "\" | " . $restoreBin . ' -q -h' . $host . ($username !== '' ? ' -U' . $username : '') . ' -p' . $port . ' ' . $database;
         } else {
-            $strCommand .= $restoreBin." -q -h".$this->objCfg->getHost().($this->objCfg->getUsername() != "" ? " -U".$this->objCfg->getUsername() : "")." -p".$port." ".$this->objCfg->getDatabase()." < \"".$strFilename."\"";
+            $command .= $restoreBin . ' -q -h' . $host . ($username !== '' ? ' -U' . $username : '') . ' -p' . $port . ' ' . $database . " < \"" . $fileName . "\"";
         }
 
-        $this->runCommand($strCommand);
+        $this->runCommand($command);
 
         return true;
     }
 
-    public function encloseTableName($strTable)
+    public function encloseTableName($table): string
     {
-        return "\"{$strTable}\"";
+        return "\"$table\"";
     }
 
-    /**
-     * @inheritDoc
-     */
-    public function escape($strValue)
+    public function escape(mixed $value): string
     {
-        return str_replace("\\", "\\\\", $strValue);
+        return str_replace("\\", "\\\\", (string) $value);
     }
 
     /**
      * Transforms the query into a valid postgres-syntax
      *
-     * @param string $strQuery
+     * @param string $query
      *
      * @return string
      */
-    protected function processQuery($strQuery)
+    protected function processQuery(string $query): string
     {
-        $strQuery = preg_replace_callback('/\?/', function($strValue){
+        $query = preg_replace_callback('/\?/', static function (): string {
             static $intI = 0;
             $intI++;
             return '$' . $intI;
-        }, $strQuery);
+        }, $query);
 
-        $strQuery = str_replace(" LIKE ", " ILIKE ", $strQuery);
-
-        return $strQuery;
+        return str_replace(' LIKE ', ' ILIKE ', $query);
     }
 
     /**
      * Does as cache-lookup for prepared statements.
      * Reduces the number of pre-compiles at the db-side.
-     *
-     * @param string $strQuery
-     *
-     * @return string|bool
-     * @since 3.4
      */
-    private function getPreparedStatementName($strQuery)
+    private function getPreparedStatementName(string $query): string | false
     {
-        $strSum = md5($strQuery);
-        if (in_array($strSum, $this->arrStatementsCache)) {
-            return $strSum;
+        $sum = md5($query);
+        if (in_array($sum, $this->statementsCache, true)) {
+            return $sum;
         }
 
-        if (pg_prepare($this->linkDB, $strSum, $strQuery)) {
-            $this->arrStatementsCache[] = $strSum;
+        if (pg_prepare($this->linkDB, $sum, $query)) {
+            $this->statementsCache[] = $sum;
         } else {
             return false;
         }
 
-        return $strSum;
+        return $sum;
     }
 
     /**
      * @inheritdoc
      */
-    public function appendLimitExpression($strQuery, $intStart, $intEnd)
+    public function appendLimitExpression(string $query, int $start, int $end): string
     {
-        //calculate the end-value:
-        $intEnd = $intEnd - $intStart + 1;
-        //add the limits to the query
-        return $strQuery." LIMIT  ".$intEnd." OFFSET ".$intStart;
+        // calculate the end-value:
+        $end = $end - $start + 1;
+        // add the limits to the query
+
+        return $query . ' LIMIT ' . $end . ' OFFSET ' . $start;
     }
 
     public function getSubstringExpression(string $value, int $offset, ?int $length): string
     {
-        $parameters = ['cast (' . $value . ' as text)' , $offset];
+        $parameters = ['cast (' . $value . ' as text)', $offset];
         if (isset($length)) {
             $parameters[] = $length;
         }
@@ -555,13 +579,13 @@ class PostgresDriver extends DriverAbstract
         return 'SUBSTRING(' . implode(', ', $parameters) . ')';
     }
 
-
     /**
      * @inheritDoc
+     * @throws QueryException
      */
-    public function flushQueryCache()
+    public function flushQueryCache(): void
     {
-        $this->_pQuery("DISCARD ALL", array());
+        $this->_pQuery('DISCARD ALL', []);
 
         parent::flushQueryCache();
     }

--- a/src/Driver/Sqlite3Driver.php
+++ b/src/Driver/Sqlite3Driver.php
@@ -22,57 +22,52 @@ use Artemeon\Database\Schema\Table;
 use Artemeon\Database\Schema\TableColumn;
 use Artemeon\Database\Schema\TableIndex;
 use Artemeon\Database\Schema\TableKey;
+use Generator;
 use SQLite3;
+use SQLite3Stmt;
+use Throwable;
 
 /**
- * db-driver for sqlite3 using the php-sqlite3-interface.
- * Based on the sqlite2 driver by phwolfer
- *
- * @since 3.3.0.1
- * @author sidler@mulchprod.de
- * @package module_system
+ * DB-driver for sqlite3 using the php-sqlite3-interface.
+ * Based on the sqlite2 driver by phwolfer.
  */
 class Sqlite3Driver extends DriverAbstract
 {
-
-    /**
-     * @var SQLite3
-     */
-    private $linkDB;
-    private $strDbFile;
+    private ?SQLite3 $linkDB;
+    private string $dbFile;
 
     /**
      * @inheritdoc
      */
-    public function dbconnect(ConnectionParameters $objParams)
+    public function dbconnect(ConnectionParameters $params): bool
     {
-        if ($objParams->getDatabase() == "") {
+        if ($params->getDatabase() === '') {
             return false;
         }
 
-        if ($objParams->getDatabase() === ':memory:') {
-            $this->strDbFile = ':memory:';
+        if ($params->getDatabase() === ':memory:') {
+            $this->dbFile = ':memory:';
         } else {
-            $this->strDbFile = $objParams->getAttribute(ConnectionParameters::SQLITE3_BASE_PATH) . '/' . $objParams->getDatabase().'.db3';
+            $this->dbFile = $params->getAttribute(ConnectionParameters::SQLITE3_BASE_PATH) . '/' . $params->getDatabase().'.db3';
         }
 
         try {
-            $this->linkDB = new SQLite3($this->strDbFile);
-            $this->_pQuery('PRAGMA encoding = "UTF-8"', array());
-            $this->_pQuery('PRAGMA auto_vacuum = FULL', array());
-            $this->_pQuery('PRAGMA journal_mode = WAL', array());
+            $this->linkDB = new SQLite3($this->dbFile);
+            $this->_pQuery('PRAGMA encoding = "UTF-8"', []);
+            $this->_pQuery('PRAGMA auto_vacuum = FULL', []);
+            $this->_pQuery('PRAGMA journal_mode = WAL', []);
             $this->linkDB->busyTimeout(5000);
 
             return true;
-        } catch (\Throwable $e) {
-            throw new ConnectionException("Error connecting to database", 0, $e);
+        } catch (Throwable $e) {
+            throw new ConnectionException('Error connecting to database', 0, $e);
         }
     }
 
     /**
      * @inheritDoc
      */
-    public function dbclose()
+    public function dbclose(): void
     {
         if ($this->linkDB !== null) {
             $this->linkDB->close();
@@ -80,211 +75,215 @@ class Sqlite3Driver extends DriverAbstract
         }
     }
 
-
-    private function buildAndCopyTempTables($strTargetTableName, $arrSourceTableInfo, $arrTargetTableInfo)
+    /**
+     * @throws QueryException
+     */
+    private function buildAndCopyTempTables(string $targetTableName, array $sourceTableInfo, array $targetTableInfo): bool
     {
         /* Get existing table info */
-        $arrPragmaTableInfo = $this->getPArray("PRAGMA table_info('{$strTargetTableName}')", array());
-        $arrColumnsPragma = array();
-        foreach ($arrPragmaTableInfo as $arrRow) {
-            $arrColumnsPragma[$arrRow['name']] = $arrRow;
+        $pragmaTableInfo = $this->getPArray("PRAGMA table_info('$targetTableName')", []);
+        $columnsPragma = [];
+        foreach ($pragmaTableInfo as $row) {
+            $columnsPragma[$row['name']] = $row;
         }
 
-        $arrSourceColumns = array();
-        array_walk($arrSourceTableInfo, function ($arrValue) use (&$arrSourceColumns) {
-            $arrSourceColumns[] = $arrValue["columnName"];
+        $sourceColumns = [];
+        array_walk($sourceTableInfo, static function (array $value) use (&$sourceColumns) {
+            $sourceColumns[] = $value['columnName'];
         });
 
-        $arrTargetColumns = array();
-        array_walk($arrTargetTableInfo, function ($arrValue) use (&$arrTargetColumns) {
-            $arrTargetColumns[] = $arrValue["columnName"];
+        $targetColumns = [];
+        array_walk($targetTableInfo, static function (array $value) use (&$targetColumns) {
+            $targetColumns[] = $value['columnName'];
         });
 
+        // build the temp table
+        $query = 'CREATE TABLE ' . $targetTableName . "_temp ( \n";
 
-        //build the a temp table
-        $strQuery = "CREATE TABLE ".$strTargetTableName."_temp ( \n";
+        // loop the fields
+        $columns = [];
+        $pks = [];
+        foreach ($targetTableInfo as $column) {
+            $row = null;
 
-        //loop the fields
-        $arrColumns = array();
-        $arrPks = array();
-        foreach ($arrTargetTableInfo as $arrOneColumn) {
-            $arrRow = null;
-
-            if (array_key_exists($arrOneColumn["columnName"], $arrColumnsPragma)) {
-                $arrRow = $arrColumnsPragma[$arrOneColumn["columnName"]];
+            if (array_key_exists($column['columnName'], $columnsPragma)) {
+                $row = $columnsPragma[$column['columnName']];
             } else {
-                $arrRow["name"] = $arrOneColumn["columnName"];
-                $arrRow["type"] = $arrOneColumn["columnType"];
+                $row['name'] = $column['columnName'];
+                $row['type'] = $column['columnType'];
             }
 
-            //column settings
-            $strColumn = " ".$arrRow["name"]." ".$arrRow["type"];
+            // column settings
+            $columnString = ' ' . $row['name'] . ' ' . $row['type'];
 
-            if (array_key_exists("notnull", $arrRow) && $arrRow["notnull"] === 1) {
-                $strColumn .= " NOT NULL ";
-            } elseif (array_key_exists("notnull", $arrRow) && $arrRow["notnull"] === 0) {
-                $strColumn .= " NULL ";
+            if (array_key_exists('notnull', $row) && $row['notnull'] === 1) {
+                $columnString .= ' NOT NULL ';
+            } elseif (array_key_exists('notnull', $row) && $row['notnull'] === 0) {
+                $columnString .= ' NULL ';
             }
 
-            if (array_key_exists("dflt_value", $arrRow) && $arrRow["dflt_value"] !== null) {
-                $strColumn .= " DEFAULT {$arrRow["dflt_value"]} ";
+            if (array_key_exists('dflt_value', $row) && $row['dflt_value'] !== null) {
+                $columnString .= " DEFAULT {$row['dflt_value']} ";
             }
-            $arrColumns[] = $strColumn;
+            $columns[] = $columnString;
 
-            //primary key?
-            if (array_key_exists("pk", $arrRow) && $arrRow["pk"] === 1) {
-                $arrPks[] = $arrRow["name"];
+            // primary key?
+            if (array_key_exists('pk', $row) && $row['pk'] === 1) {
+                $pks[] = $row['name'];
             }
         }
 
-        //columns
-        $strQuery .= implode(",\n", $arrColumns);
+        // columns
+        $query .= implode(",\n", $columns);
 
-        //primary keys
-        if (count($arrPks) > 0) {
-            $strQuery .= ",PRIMARY KEY (";
-            $strQuery .= implode(",", $arrPks);
-            $strQuery .= ")\n";
+        // primary keys
+        if (count($pks) > 0) {
+            $query .= ',PRIMARY KEY (';
+            $query .= implode(',', $pks);
+            $query .= ")\n";
         }
 
-        $strQuery .= ")\n";
+        $query .= ")\n";
 
-        $bitReturn = $this->_pQuery($strQuery, array());
+        $output = $this->_pQuery($query, []);
 
         //copy all values
-        $strQuery = "INSERT INTO ".$strTargetTableName."_temp (".implode(",", $arrTargetColumns).") SELECT ".implode(",", $arrSourceColumns)." FROM ".$strTargetTableName;
-        $bitReturn = $bitReturn && $this->_pQuery($strQuery, array());
+        $query = 'INSERT INTO ' . $targetTableName . '_temp (' . implode(',', $targetColumns) . ') SELECT ' . implode(
+                ',', $sourceColumns) . ' FROM ' . $targetTableName;
+        $output = $output && $this->_pQuery($query, []);
 
-        $strQuery = "DROP TABLE ".$strTargetTableName;
-        $bitReturn = $bitReturn && $this->_pQuery($strQuery, array());
+        $query = 'DROP TABLE ' . $targetTableName;
+        $output = $output && $this->_pQuery($query, []);
 
-        return $bitReturn && $this->renameTable($strTargetTableName."_temp", $strTargetTableName);
+        return $output && $this->renameTable($targetTableName . '_temp', $targetTableName);
     }
 
     /**
      * @inheritDoc
+     * @throws QueryException
      */
-    public function changeColumn($strTable, $strOldColumnName, $strNewColumnName, $strNewDatatype)
+    public function changeColumn(string $table, string $oldColumnName, string $newColumnName, DataType $newDataType): bool
     {
+        $tableDef = $this->getTableInformation($table);
+        $tableInfo = [];
+        $targetTableInfo = [];
+        foreach ($tableDef->getColumns() as $column) {
+            $newDef = [
+                'columnName' => $column->getName(),
+                'columnType' => $column->getInternalType(),
+            ];
 
-        $tableDef = $this->getTableInformation($strTable);
-        $arrTableInfo = array();
-        $arrTargetTableInfo = array();
-        foreach ($tableDef->getColumns() as $colDef) {
-            $arrNewDef = array(
-                "columnName" => $colDef->getName(),
-                "columnType" => $colDef->getInternalType()
-            );
+            $tableInfo[] = $newDef;
 
-            $arrTableInfo[] = $arrNewDef;
-
-            if ($colDef->getName() == $strOldColumnName) {
-                $arrNewDef = array(
-                    "columnName" => $strNewColumnName,
-                    "columnType" => $this->getDatatype($strNewDatatype)
-                );
+            if ($column->getName() === $oldColumnName) {
+                $newDef = [
+                    'columnName' => $newColumnName,
+                    'columnType' => $this->getDatatype($newDataType),
+                ];
             }
 
-            $arrTargetTableInfo[] = $arrNewDef;
+            $targetTableInfo[] = $newDef;
         }
 
-        return $this->buildAndCopyTempTables($strTable, $arrTableInfo, $arrTargetTableInfo);
+        return $this->buildAndCopyTempTables($table, $tableInfo, $targetTableInfo);
     }
 
     /**
      * @inheritDoc
+     * @throws QueryException
      */
-    public function removeColumn($strTable, $strColumn)
+    public function removeColumn(string $table, string $column): bool
     {
-        $arrTargetTableInfo = array();
+        $targetTableInfo = [];
 
-        $tableDef = $this->getTableInformation($strTable);
-        foreach ($tableDef->getColumns() as $colDef) {
-            if ($colDef->getName() != $strColumn) {
-                $arrTargetTableInfo[] = array(
-                    "columnName" => $colDef->getName(),
-                    "columnType" => $colDef->getInternalType()
-                );
+        $tableDef = $this->getTableInformation($table);
+        foreach ($tableDef->getColumns() as $col) {
+            if ($col->getName() !== $column) {
+                $targetTableInfo[] = [
+                    'columnName' => $col->getName(),
+                    'columnType' => $col->getInternalType(),
+                ];
             }
         }
 
-        return $this->buildAndCopyTempTables($strTable, $arrTargetTableInfo, $arrTargetTableInfo);
+        return $this->buildAndCopyTempTables($table, $targetTableInfo, $targetTableInfo);
     }
 
     /**
      * @inheritDoc
      */
-    public function triggerMultiInsert($strTable, $arrColumns, $arrValueSets, ConnectionInterface $objDb, ?array $arrEscapes): bool
+    public function triggerMultiInsert(string $table, array $columns, array $valueSets, ConnectionInterface $database, ?array $escapes): bool
     {
         $sqliteVersion = SQLite3::version();
         if (version_compare('3.7.11', $sqliteVersion['versionString'], '<=')) {
-            return parent::triggerMultiInsert($strTable, $arrColumns, $arrValueSets, $objDb, $arrEscapes);
+            return parent::triggerMultiInsert($table, $columns, $valueSets, $database, $escapes);
         }
+
         //legacy code
-        $safeColumns = array_map(function ($column) { return $this->encloseColumnName($column); }, $arrColumns);
+        $safeColumns = array_map(function ($column) { return $this->encloseColumnName($column); }, $columns);
         $params = [];
         $escapeValues = [];
-        $insertStatement = 'INSERT INTO ' . $this->encloseTableName($strTable) . '  (' . implode(',', $safeColumns) . ') ';
-        foreach ($arrValueSets as $key => $valueSet) {
+        $insertStatement = 'INSERT INTO ' . $this->encloseTableName($table) . ' (' . implode(',', $safeColumns) . ') ';
+        foreach ($valueSets as $key => $valueSet) {
             $selectStatement = $key === 0 ? ' SELECT ' : ' UNION SELECT ';
-            $insertStatement .= $selectStatement . implode(', ', array_map(function ($column) { return ' ? AS ' . $column; }, $safeColumns));
+            $insertStatement .= $selectStatement . implode(', ', array_map(static function ($column) { return ' ? AS ' . $column; }, $safeColumns));
             $params[] = array_values($valueSet);
-            if ($arrEscapes !== null) {
-                $escapeValues[] = $arrEscapes;
+            if ($escapes !== null) {
+                $escapeValues[] = $escapes;
             }
         }
 
-        return $objDb->_pQuery($insertStatement, array_merge(...$params), $escapeValues !== [] ? array_merge(...$escapeValues) : []);
+        return $database->_pQuery($insertStatement, array_merge(...$params), $escapeValues !== [] ? array_merge(...$escapeValues) : []);
     }
 
     /**
      * @inheritDoc
      */
-    public function insertOrUpdate($strTable, $arrColumns, $arrValues, $arrPrimaryColumns)
+    public function insertOrUpdate(string $table, array $columns, array $values, array $primaryColumns): bool
     {
-        $arrPlaceholder = array();
-        $arrMappedColumns = array();
+        $placeholders = [];
+        $mappedColumns = [];
 
-        foreach ($arrColumns as $strOneCol) {
-            $arrPlaceholder[] = "?";
-            $arrMappedColumns[] = $this->encloseColumnName($strOneCol);
+        foreach ($columns as $column) {
+            $placeholders[] = '?';
+            $mappedColumns[] = $this->encloseColumnName($column);
         }
 
-        $strQuery = "INSERT OR REPLACE INTO ".$this->encloseTableName($strTable)." (".implode(", ", $arrMappedColumns).") VALUES (".implode(", ", $arrPlaceholder).")";
-        return $this->_pQuery($strQuery, $arrValues);
+        $enclosedTableName = $this->encloseTableName($table);
+
+        $query = "INSERT OR REPLACE INTO $enclosedTableName (" . implode(', ', $mappedColumns) . ') VALUES (' . implode(
+                ', ', $placeholders) . ')';
+
+        return $this->_pQuery($query, $values);
     }
 
     /**
      * @inheritDoc
+     * @throws QueryException
      */
-    public function _pQuery($strQuery, $arrParams)
+    public function _pQuery(string $query, array $params): bool
     {
-        $strQuery = $this->fixQuoting($strQuery);
-        $strQuery = $this->processQuery($strQuery);
+        $query = $this->fixQuoting($query);
+        $query = $this->processQuery($query);
 
-        $objStmt = $this->getPreparedStatement($strQuery);
-        if ($objStmt === false) {
-            throw new QueryException('Could not prepare statement: ' . $this->getError(), $strQuery, $arrParams);
+        $statement = $this->getPreparedStatement($query);
+        if ($statement === false) {
+            throw new QueryException('Could not prepare statement: ' . $this->getError(), $query, $params);
         }
-        $intCount = 1;
-        foreach ($arrParams as $strOneParam) {
-            if ($strOneParam === null) {
-                $objStmt->bindValue(':param'.$intCount++, $strOneParam, SQLITE3_NULL);
-            }
-            //else if(is_double($strOneParam))
-            //    $objStmt->bindValue(':param'.$intCount++ , $strOneParam, SQLITE3_FLOAT);
-            //else if(is_numeric($strOneParam))
-            //    $objStmt->bindValue(':param'.$intCount++ , $strOneParam, SQLITE3_INTEGER);
-            else {
-                $objStmt->bindValue(':param'.$intCount++, $strOneParam, SQLITE3_TEXT);
+        $count = 1;
+        foreach ($params as $param) {
+            if ($param === null) {
+                $statement->bindValue(':param' . $count++, $param, SQLITE3_NULL);
+            } else {
+                $statement->bindValue(':param' . $count++, $param);
             }
         }
 
-        if ($objStmt->execute() === false) {
-            throw new QueryException('Could not execute statement: ' . $this->getError(), $strQuery, $arrParams);
+        if ($statement->execute() === false) {
+            throw new QueryException('Could not execute statement: ' . $this->getError(), $query, $params);
         }
 
-        $this->intAffectedRows = $this->linkDB->changes();
+        $this->affectedRowsCount = $this->linkDB->changes();
 
         return true;
     }
@@ -292,51 +291,47 @@ class Sqlite3Driver extends DriverAbstract
     /**
      * @inheritDoc
      */
-    public function getPArray($strQuery, $arrParams): \Generator
+    public function getPArray($query, $params): Generator
     {
-        $strQuery = $this->fixQuoting($strQuery);
-        $strQuery = $this->processQuery($strQuery);
+        $query = $this->fixQuoting($query);
+        $query = $this->processQuery($query);
 
-        $objStmt = $this->getPreparedStatement($strQuery);
-        if ($objStmt === false) {
-            throw new QueryException('Could not prepare statement: ' . $this->getError(), $strQuery, $arrParams);
+        $statement = $this->getPreparedStatement($query);
+        if ($statement === false) {
+            throw new QueryException('Could not prepare statement: ' . $this->getError(), $query, $params);
         }
 
-        $intCount = 1;
-        foreach ($arrParams as $strOneParam) {
-            if ($strOneParam === null) {
-                $objStmt->bindValue(':param'.$intCount++, $strOneParam, SQLITE3_NULL);
-            }
-            //else if(is_double($strOneParam))
-            //    $objStmt->bindValue(':param'.$intCount++ , $strOneParam, SQLITE3_FLOAT);
-            //else if(is_numeric($strOneParam))
-            //    $objStmt->bindValue(':param'.$intCount++ , $strOneParam, SQLITE3_INTEGER);
-            else {
-                $objStmt->bindValue(':param'.$intCount++, $strOneParam, SQLITE3_TEXT);
+        $count = 1;
+        foreach ($params as $param) {
+            if ($param === null) {
+                $statement->bindValue(':param' . $count++, $param, SQLITE3_NULL);
+            } else {
+                $statement->bindValue(':param' . $count++, $param);
             }
         }
 
-        $objResult = $objStmt->execute();
+        $result = $statement->execute();
 
-        if ($objResult === false) {
-            throw new QueryException('Could not execute statement', $strQuery, $arrParams);
+        if ($result === false) {
+            throw new QueryException('Could not execute statement', $query, $params);
         }
 
-        while ($arrTemp = $objResult->fetchArray(SQLITE3_ASSOC)) {
-            yield $arrTemp;
+        while ($temp = $result->fetchArray(SQLITE3_ASSOC)) {
+            yield $temp;
         }
     }
 
     /**
      * @inheritDoc
      */
-    public function getError()
+    public function getError(): string
     {
         return $this->linkDB->lastErrorMsg();
     }
 
     /**
      * @inheritDoc
+     * @throws QueryException
      */
     public function getTables(): array
     {
@@ -345,31 +340,34 @@ class Sqlite3Driver extends DriverAbstract
         foreach ($generator as $row) {
             $result[] = ['name' => strtolower($row['name'])];
         }
+
         return $result;
     }
 
     /**
      * @inheritDoc
+     * @throws QueryException
      */
     public function getTableInformation(string $tableName): Table
     {
         $table = new Table($tableName);
 
-        //fetch all columns
-        $columnInfo = $this->getPArray("PRAGMA table_info('{$tableName}')", []) ?: [];
-        foreach ($columnInfo as $arrOneColumn) {
-            $col = new TableColumn($arrOneColumn["name"]);
-            $col->setInternalType($this->getCoreTypeForDbType($arrOneColumn));
-            $col->setDatabaseType($this->getDatatype($col->getInternalType()));
-            $col->setNullable($arrOneColumn["notnull"] == 0);
-            $table->addColumn($col);
+        // fetch all columns
+        $columnInfo = $this->getPArray("PRAGMA table_info('$tableName')", []) ?: [];
+        foreach ($columnInfo as $column) {
+            $table->addColumn(
+                TableColumn::make($column['name'])
+                    ->setInternalType($this->getCoreTypeForDbType($column))
+                    ->setDatabaseType($this->getDatatype($this->getCoreTypeForDbType($column)))
+                    ->setNullable($column['notnull'] == 0),
+            );
 
-            if ($arrOneColumn['pk'] == 1) {
-                $table->addPrimaryKey(new TableKey($arrOneColumn["name"]));
+            if ($column['pk'] == 1) {
+                $table->addPrimaryKey(new TableKey($column['name']));
             }
         }
 
-        //fetch all indexes
+        // fetch all indexes
         $indexes = $this->getPArray("SELECT * FROM sqlite_master WHERE type = 'index' AND tbl_name = ?", [$tableName]) ?: [];
         foreach ($indexes as $indexInfo) {
             $index = new TableIndex($indexInfo['name']);
@@ -381,114 +379,121 @@ class Sqlite3Driver extends DriverAbstract
     }
 
     /**
-     * Tries to convert a column provided by the database back to the Kajona internal type constant
-     * @param $infoSchemaRow
-     * @return null|string
+     * Tries to convert a column provided by the database back to the Kajona internal type constant.
      */
-    private function getCoreTypeForDbType($infoSchemaRow)
+    private function getCoreTypeForDbType(array $infoSchemaRow): ?DataType
     {
-        $val = strtolower(trim($infoSchemaRow["type"]));
-        if ($val == "integer") {
-            return DataType::STR_TYPE_INT;
-        } elseif ($val == "real") {
-            return DataType::STR_TYPE_DOUBLE;
-        } elseif ($val == "text") {
-            return DataType::STR_TYPE_TEXT;
+        $val = strtolower(trim($infoSchemaRow['type']));
+
+        if ($val === 'integer') {
+            return DataType::INT;
         }
+
+        if ($val === 'real') {
+            return DataType::FLOAT;
+        }
+
+        if ($val === 'text') {
+            return DataType::TEXT;
+        }
+
         return null;
     }
 
     /**
      * @inheritDoc
+     * @throws QueryException
      */
-    public function createTable($strName, $arrFields, $arrKeys)
+    public function createTable(string $name, array $columns, array $primaryKeys): bool
     {
-        $strQuery = "";
+        $query = "CREATE TABLE $name ( \n";
 
-        //build the mysql code
-        $strQuery .= "CREATE TABLE ".$strName." ( \n";
+        // loop the fields
+        foreach ($columns as $fieldName => $columnSettings) {
+            $query .= " $fieldName ";
 
-        //loop the fields
-        foreach ($arrFields as $strFieldName => $arrColumnSettings) {
-            $strQuery .= " ".$strFieldName." ";
+            $query .= $this->getDatatype($columnSettings[0]);
 
-            $strQuery .= $this->getDatatype($arrColumnSettings[0]);
-
-            //any default?
-            if (isset($arrColumnSettings[2])) {
-                $strQuery .= " DEFAULT ".$arrColumnSettings[2]." ";
+            // any default?
+            if (isset($columnSettings[2])) {
+                $query .= ' DEFAULT ' . $columnSettings[2] . ' ';
             }
 
-            //nullable?
-            if ($arrColumnSettings[1] === true) {
-                $strQuery .= ", \n";
+            // nullable?
+            if ($columnSettings[1] === true) {
+                $query .= ", \n";
             } else {
-                $strQuery .= " NOT NULL, \n";
+                $query .= " NOT NULL, \n";
             }
-
         }
 
-        //primary keys
-        $strQuery .= " PRIMARY KEY (".implode(", ", $arrKeys).") \n";
-        $strQuery .= ") ";
+        // primary keys
+        $query .= ' PRIMARY KEY (' . implode(', ', $primaryKeys) . ") \n";
+        $query .= ') ';
 
-        return $this->_pQuery($strQuery, array());
+        return $this->_pQuery($query, []);
+    }
+
+    /**
+     * @inheritdoc
+     * @throws QueryException
+     */
+    public function hasIndex($table, $name): bool
+    {
+        $index = iterator_to_array($this->getPArray("SELECT name FROM sqlite_master WHERE type = 'index' AND tbl_name = ? AND name = ?", [$table, $name]), false);
+        return count($index) > 0;
+    }
+
+    /**
+     * @inheritDoc
+     * @throws QueryException
+     */
+    public function beginTransaction(): void
+    {
+        $this->_pQuery('BEGIN TRANSACTION', []);
+    }
+
+    /**
+     * @inheritDoc
+     * @throws QueryException
+     */
+    public function commitTransaction(): void
+    {
+        $this->_pQuery('COMMIT TRANSACTION', []);
+    }
+
+    /**
+     * @inheritDoc
+     * @throws QueryException
+     */
+    public function rollbackTransaction(): void
+    {
+        $this->_pQuery('ROLLBACK TRANSACTION', []);
+    }
+
+    /**
+     * @inheritDoc
+     * @throws QueryException
+     */
+    public function getDbInfo(): array
+    {
+        $timeout = iterator_to_array($this->getPArray('PRAGMA busy_timeout', []), false);
+        $encoding = iterator_to_array($this->getPArray('PRAGMA encoding', []), false);
+
+        $db = $this->linkDB->version();
+
+        return [
+            'dbserver' => 'SQLite3 ' . $db['versionString'] . ' ' . $db['versionNumber'],
+            'location' => $this->dbFile,
+            'busy_timeout' => $timeout[0]['timeout'] ?? '-',
+            'encoding' => $encoding[0]['encoding'] ?? '-',
+        ];
     }
 
     /**
      * @inheritdoc
      */
-    public function hasIndex($strTable, $strName): bool
-    {
-        $arrIndex = iterator_to_array($this->getPArray("SELECT name FROM sqlite_master WHERE type = 'index' AND tbl_name = ? AND name = ?", [$strTable, $strName]), false);
-        return count($arrIndex) > 0;
-    }
-
-    /**
-     * @inheritDoc
-     */
-    public function transactionBegin()
-    {
-        $this->_pQuery("BEGIN TRANSACTION", array());
-    }
-
-    /**
-     * @inheritDoc
-     */
-    public function transactionCommit()
-    {
-        $this->_pQuery("COMMIT TRANSACTION", array());
-    }
-
-    /**
-     * @inheritDoc
-     */
-    public function transactionRollback()
-    {
-        $this->_pQuery("ROLLBACK TRANSACTION", array());
-    }
-
-    /**
-     * @inheritDoc
-     */
-    public function getDbInfo()
-    {
-        $timeout = iterator_to_array($this->getPArray("PRAGMA busy_timeout", array()), false);
-        $encoding = iterator_to_array($this->getPArray("PRAGMA encoding", array()), false);
-
-        $arrDB = $this->linkDB->version();
-        $arrReturn = [];
-        $arrReturn["dbserver"] = "SQLite3 ".$arrDB["versionString"]." ".$arrDB["versionNumber"];
-        $arrReturn["location"] = $this->strDbFile;
-        $arrReturn["busy timeout"] = $timeout[0]["timeout"] ?? '-';
-        $arrReturn["encoding"] = $encoding[0]["encoding"] ?? '-';
-        return $arrReturn;
-    }
-
-    /**
-     * @inheritdoc
-     */
-    public function handlesDumpCompression()
+    public function handlesDumpCompression(): bool
     {
         return false;
     }
@@ -496,122 +501,81 @@ class Sqlite3Driver extends DriverAbstract
     /**
      * @inheritDoc
      */
-    public function dbExport(&$strFilename, $arrTables)
+    public function dbExport(string &$fileName, array $tables): bool
     {
-        // @TODO implement
         return false;
     }
 
     /**
      * @inheritDoc
      */
-    public function dbImport($strFilename)
+    public function dbImport(string $fileName): bool
     {
-        // @TODO implement
         return false;
     }
 
     /**
      * @inheritDoc
      */
-    public function getDatatype($strType)
+    public function getDatatype(DataType $type): string
     {
-        $strReturn = "";
-
-        if ($strType == DataType::STR_TYPE_INT) {
-            $strReturn .= " INTEGER ";
-        } elseif ($strType == DataType::STR_TYPE_LONG) {
-            $strReturn .= " INTEGER ";
-        } elseif ($strType == DataType::STR_TYPE_DOUBLE) {
-            $strReturn .= " REAL ";
-        } elseif ($strType == DataType::STR_TYPE_CHAR10) {
-            $strReturn .= " TEXT ";
-        } elseif ($strType == DataType::STR_TYPE_CHAR20) {
-            $strReturn .= " TEXT ";
-        } elseif ($strType == DataType::STR_TYPE_CHAR100) {
-            $strReturn .= " TEXT ";
-        } elseif ($strType == DataType::STR_TYPE_CHAR254) {
-            $strReturn .= " TEXT ";
-        } elseif ($strType == DataType::STR_TYPE_CHAR500) {
-            $strReturn .= " TEXT ";
-        } elseif ($strType == DataType::STR_TYPE_TEXT) {
-            $strReturn .= " TEXT ";
-        } elseif ($strType == DataType::STR_TYPE_LONGTEXT) {
-            $strReturn .= " TEXT ";
-        } else {
-            $strReturn .= " TEXT ";
-        }
-
-        return $strReturn;
+        return match ($type) {
+            DataType::INT, DataType::BIGINT => ' INTEGER ',
+            DataType::FLOAT => ' REAL ',
+            default => ' TEXT ',
+        };
     }
 
     /**
      * Fixes the quoting of ' in queries.
-     * By default ' is quoted as \', but it must be quoted as '' in sqlite.
-     *
-     * @param string $strSql
-     *
-     * @return string
+     * By default, ' is quoted as \', but it must be quoted as '' in sqlite.
      */
-    private function fixQuoting($strSql)
+    private function fixQuoting(string $query): string
     {
-        $strSql = str_replace("\\'", "''", $strSql);
-        $strSql = str_replace("\\\"", "\"", $strSql);
-        return $strSql;
+        return str_replace(["\\'", "\\\""], ["''", "\""], $query);
     }
 
     /**
-     * Transforms the query into a valid sqlite-syntax
-     *
-     * @param string $strQuery
-     *
-     * @return string
+     * Transforms the query into a valid sqlite-syntax.
      */
-    private function processQuery($strQuery)
+    private function processQuery(string $query): string
     {
-        $strQuery = preg_replace_callback('/\?/', static function($value): string {
+        return preg_replace_callback('/\?/', static function (): string {
             static $i = 0;
             $i++;
             return ':param' . $i;
-        }, $strQuery);
-
-        return $strQuery;
+        }, $query);
     }
 
     /**
-     * Prepares a statement or uses an instance from the cache
-     *
-     * @param string $strQuery
-     *
-     * @return \SQLite3Stmt|false
+     * Prepares a statement or uses an instance from the cache.
      */
-    private function getPreparedStatement($strQuery)
+    private function getPreparedStatement(string $query): SQLite3Stmt | false
     {
+        $name = md5($query);
 
-        $strName = md5($strQuery);
-
-        if (isset($this->arrStatementsCache[$strName])) {
-            return $this->arrStatementsCache[$strName];
+        if (isset($this->statementsCache[$name])) {
+            return $this->statementsCache[$name];
         }
 
-        $objStmt = $this->linkDB->prepare($strQuery);
-        $this->arrStatementsCache[$strName] = $objStmt;
+        $statement = $this->linkDB->prepare($query);
+        $this->statementsCache[$name] = $statement;
 
-        return $objStmt;
+        return $statement;
     }
 
     /**
      * @inheritDoc
      */
-    public function encloseTableName($strTable)
+    public function encloseTableName(string $table): string
     {
-        return "'".$strTable."'";
+        return "'$table'";
     }
 
     /**
      * @inheritdoc
      */
-    public function getConcatExpression(array $parts)
+    public function getConcatExpression(array $parts): string
     {
         return implode(' || ', $parts);
     }

--- a/src/Driver/SqlsrvDriver.php
+++ b/src/Driver/SqlsrvDriver.php
@@ -307,17 +307,17 @@ class SqlsrvDriver extends DriverAbstract
         $enclosedTableName = $this->encloseTableName($table);
         $enclosedColumnName = $this->encloseColumnName($column);
 
-        $strQuery = "ALTER TABLE $enclosedTableName ADD $enclosedColumnName " . $this->getDatatype($dataType);
+        $query = "ALTER TABLE $enclosedTableName ADD $enclosedColumnName " . $this->getDatatype($dataType);
 
         if ($default !== null) {
-            $strQuery .= " DEFAULT $default";
+            $query .= " DEFAULT $default";
         }
 
         if ($nullable !== null) {
-            $strQuery .= $nullable ? ' NULL' : ' NOT NULL';
+            $query .= $nullable ? ' NULL' : ' NOT NULL';
         }
 
-        return $this->_pQuery($strQuery, []);
+        return $this->_pQuery($query, []);
     }
 
     /**
@@ -528,7 +528,7 @@ class SqlsrvDriver extends DriverAbstract
         // OFFSET and FETCH can only be used with an ORDER BY.
         if (!$this->containsOrderBy($query)) {
             // Should be fixed but produces a file write on every call, so it is bad for the performance.
-            // Logger::getInstance(Logger::DBLOG)->warning("Using a limit expression without an order by: {$strQuery}");
+            // Logger::getInstance(Logger::DBLOG)->warning("Using a limit expression without an order by: {$query}");
 
             $query .= ' ORDER BY 1 ASC ';
         }

--- a/src/DriverFactory.php
+++ b/src/DriverFactory.php
@@ -16,15 +16,11 @@ namespace Artemeon\Database;
 use Artemeon\Database\Exception\DriverNotFoundException;
 
 /**
- * Factory to create a fitting driver based on the driver string
- *
- * @since 7.3
+ * Factory to create a fitting driver based on the driver string.
  */
 class DriverFactory
 {
     /**
-     * @param string $driver
-     * @return DriverInterface
      * @throws DriverNotFoundException
      */
     public function factory(string $driver): DriverInterface

--- a/src/DriverInterface.php
+++ b/src/DriverInterface.php
@@ -41,7 +41,7 @@ interface DriverInterface
     /**
      * Creates a single query in order to insert multiple rows at one time.
      * For most databases, this will create s.th. like
-     * INSERT INTO $strTable ($arrColumns) VALUES (?, ?), (?, ?)...
+     * INSERT INTO $table ($columns) VALUES (?, ?), (?, ?)...
      * Please note that this method is used to create the query itself, based on the Kajona-internal syntax.
      * The query is fired to the database by Database.
      */
@@ -52,8 +52,6 @@ interface DriverInterface
      * to detect whether a row is already present or not.
      * Please note: since some dbrms fire a delete && insert, make sure to pass ALL colums and values,
      * otherwise data might be lost.
-     *
-     * @internal param $strPrimaryColumn
      */
     public function insertOrUpdate(string $table, array $columns, array $values, array $primaryColumns): bool;
 

--- a/src/DriverInterface.php
+++ b/src/DriverInterface.php
@@ -15,413 +15,263 @@ namespace Artemeon\Database;
 
 use Artemeon\Database\Exception\ConnectionException;
 use Artemeon\Database\Exception\QueryException;
+use Artemeon\Database\Schema\DataType;
 use Artemeon\Database\Schema\Table;
 use Artemeon\Database\Schema\TableIndex;
+use Generator;
 
 /**
  * Interface to specify the layout of db-drivers.
  * Implement this interface, if you want to provide a db-layer for Kajona.
- *
- * @package module_system
  */
 interface DriverInterface
 {
-
     /**
-     * This method makes sure to connect to the database properly
+     * This method makes sure to connect to the database properly.
      *
-     * @param ConnectionParameters $objParams
-     * @return bool
      * @throws ConnectionException
      */
-    public function dbconnect(ConnectionParameters $objParams);
+    public function dbconnect(ConnectionParameters $params): bool;
 
     /**
-     * Closes the connection to the database
-     *
-     * @return void
+     * Closes the connection to the database.
      */
-    public function dbclose();
+    public function dbclose(): void;
 
     /**
      * Creates a single query in order to insert multiple rows at one time.
      * For most databases, this will create s.th. like
      * INSERT INTO $strTable ($arrColumns) VALUES (?, ?), (?, ?)...
      * Please note that this method is used to create the query itself, based on the Kajona-internal syntax.
-     * The query is fired to the database by Database
-     *
-     * @param string $strTable
-     * @param string[] $arrColumns
-     * @param array $arrValueSets
-     * @param ConnectionInterface $objDb
-     *
-     * @param array|null $arrEscapes
-     * @return bool
+     * The query is fired to the database by Database.
      */
-    public function triggerMultiInsert($strTable, $arrColumns, $arrValueSets, ConnectionInterface $objDb, ?array $arrEscapes);
+    public function triggerMultiInsert(string $table, array $columns, array $valueSets, ConnectionInterface $database, ?array $escapes): bool;
 
     /**
-     * Fires an insert or update of a single record. it's up to the database (driver)
+     * Fires an insert or update of a single record. It is up to the database (driver)
      * to detect whether a row is already present or not.
      * Please note: since some dbrms fire a delete && insert, make sure to pass ALL colums and values,
      * otherwise data might be lost.
      *
-     * @param $strTable
-     * @param $arrColumns
-     * @param $arrValues
-     * @param $arrPrimaryColumns
-     *
-     * @return bool
      * @internal param $strPrimaryColumn
-     *
      */
-    public function insertOrUpdate($strTable, $arrColumns, $arrValues, $arrPrimaryColumns);
+    public function insertOrUpdate(string $table, array $columns, array $values, array $primaryColumns): bool;
 
     /**
-     * Sends a prepared statement to the database. All params must be represented by the ? char.
+     * Sends a prepared statement to the database. All params must be represented by the "?" char.
      * The params themselves are stored using the second params using the matching order.
-     *
-     * @param string $strQuery
-     * @param array<int, scalar> $arrParams
-     *
-     * @return bool
-     * @since 3.4
      */
-    public function _pQuery($strQuery, $arrParams);
+    public function _pQuery(string $query, array $params): bool;
 
     /**
-     * This method is used to retrieve an array of resultsets from the database using
-     * a prepared statement
+     * This method is used to retrieve an array of result-sets from the database using
+     * a prepared statement.
      *
-     * @param string $strQuery
-     * @param array $arrParams
-     *
-     * @since 3.4
-     * @return \Generator
      * @throws QueryException
      */
-    public function getPArray($strQuery, $arrParams): \Generator;
+    public function getPArray(string $query, array $params): Generator;
 
     /**
      * Returns the last error reported by the database.
-     * Is being called after unsuccessful queries
-     *
-     * @return string
+     * Is being called after unsuccessful queries.
      */
-    public function getError();
+    public function getError(): string;
 
     /**
      * Returns ALL tables in the database currently connected to.
      * The method should return an array using the following keys:
      * name => Table name
-     *
-     * @return array
      */
     public function getTables(): array;
 
     /**
-     * Fetches the full table information as retrieved from the rdbms
-     * @param $tableName
-     * @return Table
+     * Fetches the full table information as retrieved from the rdbms.
      */
     public function getTableInformation(string $tableName): Table;
 
 
-
     /**
-     * Used to send a create table statement to the database
-     * By passing the query through this method, the driver can
-     * add db-specific commands.
+     * Used to send a CREATE table statement to the database
+     * By passing the query through this method, the driver can add db-specific commands.
      * The array of fields should have the following structure
-     * $array[string columnName] = array(string datatype, boolean isNull [, default (only if not null)])
+     * $array[string columnName] = [{@see DataType} datatype, bool isNull [, default (only if not null)]]
      * whereas datatype is one of the following:
-     *        int
-     *      long
-     *        double
-     *        char10
-     *        char20
-     *        char100
-     *        char254
-     *      char500
-     *        text
-     *      longtext
-     *
-     * @param string $strName
-     * @param array $arrFields array of fields / columns
-     * @param array $arrKeys array of primary keys
-     *
-     * @return bool
+     *  - int
+     *  - long
+     *  - double
+     *  - char10
+     *  - char20
+     *  - char100
+     *  - char254
+     *  - char500
+     *  - text
+     *  - longtext
      */
-    public function createTable($strName, $arrFields, $arrKeys);
+    public function createTable(string $name, array $columns, array $primaryKeys): bool;
 
     /**
      * Creates a new index on the provided table over the given columns. If unique is true we create a unique index
-     * where each index can only occur once in the table
-     *
-     * @param string $strTable
-     * @param string $strName
-     * @param array $arrColumns
-     * @param bool $bitUnique
-     * @return bool
+     * where each index can only occur once in the table.
      */
-    public function createIndex($strTable, $strName, $arrColumns, $bitUnique = false);
+    public function createIndex(string $table, string $name, array $columns, bool $unique = false): bool;
 
     /**
-     * Deletes an index from the database
-     * @param string $table
-     * @param string $index
-     * @return bool
+     * Deletes an index from the database.
      */
     public function deleteIndex(string $table, string $index): bool;
 
     /**
-     * Adds a new index to the provided table
-     * @param TableIndex $index
-     * @return bool
+     * Adds a new index to the provided table.
      */
     public function addIndex(string $table, TableIndex $index): bool;
 
     /**
-     * Checks whether the table has an index with the provided name
-     *
-     * @param string $strTable
-     * @param string $strName
-     * @return bool
+     * Checks whether the table has an index with the provided name.
      */
-    public function hasIndex($strTable, $strName): bool;
+    public function hasIndex(string $table, string $name): bool;
 
     /**
-     * Returns whether a column exists on a table
-     *
-     * @param string $tableName
-     * @param string $columnName
-     * @return bool
+     * Returns whether a column exists on a table.
      */
     public function hasColumn(string $tableName, string $columnName): bool;
 
     /**
-     * Renames a table
-     *
-     * @param $strOldName
-     * @param $strNewName
-     *
-     * @return bool
-     * @since 4.6
+     * Renames a table.
      */
-    public function renameTable($strOldName, $strNewName);
-
+    public function renameTable(string $oldName, string $newName): bool;
 
     /**
-     * Changes a single column, e.g. the datatype
-     *
-     * @param $strTable
-     * @param $strOldColumnName
-     * @param $strNewColumnName
-     * @param $strNewDatatype
-     *
-     * @return bool
-     * @since 4.6
+     * Changes a single column, e.g. the datatype.
      */
-    public function changeColumn($strTable, $strOldColumnName, $strNewColumnName, $strNewDatatype);
+    public function changeColumn(string $table, string $oldColumnName, string $newColumnName, DataType $newDataType): bool;
 
     /**
-     * Adds a column to a table
-     *
-     * @param $strTable
-     * @param $strColumn
-     * @param $strDatatype
-     *
-     * @return bool
-     * @since 4.6
+     * Adds a column to a table.
      */
-    public function addColumn($strTable, $strColumn, $strDatatype, $bitNull = null, $strDefault = null);
+    public function addColumn(string $table, string $column, DataType $dataType, ?bool $nullable = null, ?string $default = null): bool;
 
     /**
-     * Removes a column from a table
-     *
-     * @param $strTable
-     * @param $strColumn
-     *
-     * @return bool
-     * @since 4.6
+     * Removes a column from a table.
      */
-    public function removeColumn($strTable, $strColumn);
+    public function removeColumn(string $table, string $column): bool;
 
     /**
-     * Starts a transaction
-     *
-     * @return void
-     * @since 4.6
+     * Starts a transaction.
      */
-    public function transactionBegin();
+    public function beginTransaction(): void;
 
     /**
-     * Ends a successful operation by committing the transaction
-     *
-     * @return void
-     * @since 4.6
+     * Ends a successful operation by committing the transaction.
      */
-    public function transactionCommit();
+    public function commitTransaction(): void;
 
     /**
-     * Ends a non-successful transaction by using a rollback
-     *
-     * @return void
+     * Ends a non-successful transaction by using a rollback.
      */
-    public function transactionRollback();
+    public function rollbackTransaction(): void;
 
     /**
-     * returns an array of key value pairs with infos about the current database
+     * Returns an array of key value pairs with infos about the current database
      * The array returned should have tho following structure:
      *  property name => value
-     *
-     * @return array
      */
-    public function getDbInfo();
+    public function getDbInfo(): array;
 
     /**
-     * Creates an db-dump usind the given filename. the filename is relative to _realpath_
-     * The dump must include, and ONLY include the pass tables
+     * Creates an db-dump using the given filename. The filename is relative to _realpath_
+     * The dump must include, and ONLY include the pass tables.
      *
-     * @param string &$strFilename passed by reference so that the driver is able to update the filename, e.g. in order to add a .gz suffix
-     * @param array $arrTables
-     *
-     * @return bool Indicates, if the dump worked or not
+     * @param string &$fileName passed by reference so that the driver is able to update the filename, e.g. in order to add a .gz suffix.
      */
-    public function dbExport(&$strFilename, $arrTables);
+    public function dbExport(string &$fileName, array $tables): bool;
 
     /**
-     * Imports the given db-dump file to the database. The filename ist relative to _realpath_
-     *
-     * @param string $strFilename
-     *
-     * @return bool
+     * Imports the given db-dump file to the database. The filename ist relative to _realpath_.
      */
-    public function dbImport($strFilename);
+    public function dbImport(string $fileName): bool;
 
     /**
      * Allows the db-driver to add database-specific surroundings to column-names.
-     * E.g. needed by the mysql-drivers
-     *
-     * @param string $strColumn
-     *
-     * @return string
+     * E.g. needed by the mysql-drivers.
      */
-    public function encloseColumnName($strColumn);
+    public function encloseColumnName(string $column): string;
 
     /**
      * Allows the db-driver to add database-specific surroundings to table-names.
-     * E.g. needed by the mysql-drivers
-     *
-     * @param string $strTable
-     *
-     * @return string
+     * E.g. needed by the mysql-drivers.
      */
-    public function encloseTableName($strTable);
+    public function encloseTableName(string $table): string;
 
     /**
      * Returns the db-specific datatype for the kajona internal datatype.
-     *
-     * @param string $strType
-     *
-     * @return string
-     * @see DbDatatypes
      */
-    public function getDatatype($strType);
+    public function getDatatype(DataType $type): string;
 
     /**
      * A method triggered in special cases in order to
      * have even the caches stored at the db-driver being flushed.
      * This could get important in case of schema updates since precompiled queries may get invalid due
      * to updated table definitions.
-     *
-     * @return void
      */
-    public function flushQueryCache();
+    public function flushQueryCache(): void;
 
-    /**
-     * @param string $strValue
-     *
-     * @return mixed
-     */
-    public function escape($strValue);
+    public function escape(mixed $value): mixed;
 
     /**
      * Appends a limit expression to the provided query. The start and end parameter are the positions of the start and
-     * end row which you want include in your resultset. I.e. to return a single row use 0, 0. To return the first 8
-     * rows use 0, 7.
-     *
-     * @param string $strQuery
-     * @param int $intStart
-     * @param int $intEnd
-     * @return string
+     * end row, which you want to include in your result-set. I.e. to return a single row use 0, 0. To return the first
+     * 8 rows use 0, 7.
      */
-    public function appendLimitExpression($strQuery, $intStart, $intEnd);
+    public function appendLimitExpression(string $query, int $start, int $end): string;
 
     /**
-     * Returns a query expression which concatenates different values. This can bei either column names or strings.
+     * Returns a query expression, which concatenates different values. This can bei either column names or strings.
      * <code>
      *  $connection->getConcatExpression(['user_kajona.user_forename', '\' \'', 'user_kajona.user_name'])
      * </code>
-     *
-     * @param array $parts
-     * @return string
      */
-    public function getConcatExpression(array $parts);
+    public function getConcatExpression(array $parts): string;
 
     /**
-     * Returns the number of affected rows from the last _pQuery call
+     * Returns the number of affected rows from the last _pQuery call.
      *
      * @return int
      */
-    public function getIntAffectedRows();
-
+    public function getAffectedRowsCount(): int;
 
     /**
      * Default implementation to detect if a driver handles compression.
-     * By default, db-drivers us a piped gzip / gunzip command when creating / restoring dumps on unix.
+     * By default, db-drivers us a piped gzip / gunzip command when creating / restoring dumps on UNIX.
      * If running on windows, the Database class handles the compression / decompression.
-     *
-     * @return bool
      */
-    public function handlesDumpCompression();
+    public function handlesDumpCompression(): bool;
 
     /**
-     * Method which converts a PHP value to a value which can be inserted into a table. I.e. it truncates the value to
-     * the fitting length for the provided datatype
-     *
-     * @param mixed $value
-     * @param string $type
-     * @return mixed
+     * Convert a PHP value to a value, which can be inserted into a table. I.e. it truncates the value to
+     * the fitting length for the provided datatype.
      */
-    public function convertToDatabaseValue($value, string $type);
+    public function convertToDatabaseValue(mixed $value, DataType $type): mixed;
 
     /**
-     * Returns a LEAST() query expression which selects the minimum value of given columns.
+     * Returns a "LEAST()" query expression, which selects the minimum value of given columns.
      * <code>
      *  $connection->getLeastExpression(['column1','column2', ...])
      * </code>
-     *
-     * @param array $parts
-     * @return string
      */
     public function getLeastExpression(array $parts): string;
 
     /**
      * Builds a query expression to retrieve a substring of the given column name or value.
      *
-     * The offset of the substring inside of the value must be given as 1-based index. If a length is given, only up to
+     * The offset of the substring inside the value must be given as 1-based index. If a length is given, only up to
      * this number of characters are extracted; if no length is given, everything to the end of the value is extracted.
-     * *Note*: Negative offsets or lengths are not guaranteed to work across different database drivers.
+     * *Note*: It is not guaranteed that negative offsets or lengths work across different database drivers.
      */
     public function getSubstringExpression(string $value, int $offset, ?int $length): string;
 
     /**
      * Returns the database-specific string-length expression, e.g. LEN() or LENGTH().
-     * Pass the value to be counted (e.g. a column name) by param
-     *
+     * Pass the value to be counted (e.g. a column name) by param.
      */
     public function getStringLengthExpression(string $targetString): string;
 }
-
-

--- a/src/EscapeableParameterInterface.php
+++ b/src/EscapeableParameterInterface.php
@@ -13,18 +13,8 @@ declare(strict_types=1);
 
 namespace Artemeon\Database;
 
-/**
- * @since 7.3
- */
 interface EscapeableParameterInterface
 {
-    /**
-     * @return bool
-     */
     public function isEscape(): bool;
-
-    /**
-     * @return mixed
-     */
-    public function getValue();
+    public function getValue(): mixed;
 }

--- a/src/Exception/AddColumnException.php
+++ b/src/Exception/AddColumnException.php
@@ -13,34 +13,21 @@ declare(strict_types=1);
 
 namespace Artemeon\Database\Exception;
 
+use Artemeon\Database\Schema\DataType;
+
 class AddColumnException extends \Exception
 {
-    /**
-     * @var string
-     */
-    private $table;
+    private string $table;
 
-    /**
-     * @var string
-     */
-    private $column;
+    private string $column;
 
-    /**
-     * @var string
-     */
-    private $dataType;
+    private DataType $dataType;
 
-    /**
-     * @var bool|null
-     */
-    private $null;
+    private ?bool $null;
 
-    /**
-     * @var string|null
-     */
-    private $default;
+    private ?string $default;
 
-    public function __construct(string $message, string $table, string $column, string $dataType, ?bool $null = null, ?string $default = null, ?\Throwable $previous = null)
+    public function __construct(string $message, string $table, string $column, DataType $dataType, ?bool $null = null, ?string $default = null, ?\Throwable $previous = null)
     {
         parent::__construct($message, 0, $previous);
 
@@ -51,41 +38,26 @@ class AddColumnException extends \Exception
         $this->default = $default;
     }
 
-    /**
-     * @return string
-     */
     public function getTable(): string
     {
         return $this->table;
     }
 
-    /**
-     * @return string
-     */
     public function getColumn(): string
     {
         return $this->column;
     }
 
-    /**
-     * @return string
-     */
     public function getDataType(): string
     {
-        return $this->dataType;
+        return $this->dataType->value;
     }
 
-    /**
-     * @return bool|null
-     */
     public function getNull(): ?bool
     {
         return $this->null;
     }
 
-    /**
-     * @return string|null
-     */
     public function getDefault(): ?string
     {
         return $this->default;

--- a/src/Exception/ChangeColumnException.php
+++ b/src/Exception/ChangeColumnException.php
@@ -13,12 +13,11 @@ declare(strict_types=1);
 
 namespace Artemeon\Database\Exception;
 
+use Artemeon\Database\Schema\DataType;
+
 class ChangeColumnException extends \Exception
 {
-    /**
-     * @var string
-     */
-    private $table;
+    private string $table;
 
     /**
      * @var string
@@ -35,7 +34,7 @@ class ChangeColumnException extends \Exception
      */
     private $newDataType;
 
-    public function __construct(string $message, string $table, string $oldColumnName, string $newColumnName, string $newDataType, ?\Throwable $previous = null)
+    public function __construct(string $message, string $table, string $oldColumnName, string $newColumnName, DataType $newDataType, ?\Throwable $previous = null)
     {
         parent::__construct($message, 0, $previous);
 

--- a/src/Exception/CommitException.php
+++ b/src/Exception/CommitException.php
@@ -13,6 +13,8 @@ declare(strict_types=1);
 
 namespace Artemeon\Database\Exception;
 
-class CommitException extends \Exception
+use Exception;
+
+class CommitException extends Exception
 {
 }

--- a/src/Exception/ConnectionException.php
+++ b/src/Exception/ConnectionException.php
@@ -13,6 +13,8 @@ declare(strict_types=1);
 
 namespace Artemeon\Database\Exception;
 
-class ConnectionException extends \Exception
+use Exception;
+
+class ConnectionException extends Exception
 {
 }

--- a/src/Exception/ConnectionNotFoundException.php
+++ b/src/Exception/ConnectionNotFoundException.php
@@ -13,6 +13,8 @@ declare(strict_types=1);
 
 namespace Artemeon\Database\Exception;
 
-class ConnectionNotFoundException extends \Exception
+use Exception;
+
+class ConnectionNotFoundException extends Exception
 {
 }

--- a/src/Exception/DriverNotFoundException.php
+++ b/src/Exception/DriverNotFoundException.php
@@ -13,6 +13,8 @@ declare(strict_types=1);
 
 namespace Artemeon\Database\Exception;
 
-class DriverNotFoundException extends \Exception
+use Exception;
+
+class DriverNotFoundException extends Exception
 {
 }

--- a/src/Exception/QueryException.php
+++ b/src/Exception/QueryException.php
@@ -13,19 +13,14 @@ declare(strict_types=1);
 
 namespace Artemeon\Database\Exception;
 
+use Exception;
 use Throwable;
 
-class QueryException extends \Exception
+class QueryException extends Exception
 {
-    /**
-     * @var string
-     */
-    private $query;
+    private string $query;
 
-    /**
-     * @var array
-     */
-    private $params;
+    private array $params;
 
     public function __construct(string $message, string $query, array $params, Throwable $previous = null)
     {
@@ -35,17 +30,11 @@ class QueryException extends \Exception
         $this->params = $params;
     }
 
-    /**
-     * @return string
-     */
     public function getQuery(): string
     {
         return $this->query;
     }
 
-    /**
-     * @return array
-     */
     public function getParams(): array
     {
         return $this->params;

--- a/src/Exception/RemoveColumnException.php
+++ b/src/Exception/RemoveColumnException.php
@@ -13,19 +13,16 @@ declare(strict_types=1);
 
 namespace Artemeon\Database\Exception;
 
-class RemoveColumnException extends \Exception
+use Exception;
+use Throwable;
+
+class RemoveColumnException extends Exception
 {
-    /**
-     * @var string
-     */
-    private $table;
+    private string $table;
 
-    /**
-     * @var string
-     */
-    private $column;
+    private string $column;
 
-    public function __construct(string $message, string $table, string $column, ?\Throwable $previous = null)
+    public function __construct(string $message, string $table, string $column, ?Throwable $previous = null)
     {
         parent::__construct($message, 0, $previous);
 
@@ -33,17 +30,11 @@ class RemoveColumnException extends \Exception
         $this->column = $column;
     }
 
-    /**
-     * @return string
-     */
     public function getTable(): string
     {
         return $this->table;
     }
 
-    /**
-     * @return string
-     */
     public function getColumn(): string
     {
         return $this->column;

--- a/src/Exception/TableNotFoundException.php
+++ b/src/Exception/TableNotFoundException.php
@@ -8,15 +8,14 @@ declare(strict_types=1);
 
 namespace Artemeon\Database\Exception;
 
+use Exception;
 use Throwable;
 
-class TableNotFoundException extends \Exception
+class TableNotFoundException extends Exception
 {
-
     public function __construct(string $table, Throwable $previous = null)
     {
         $this->message = 'Table not found:  ' . $table;
         parent::__construct($this->message, 0, $previous);
     }
-
 }

--- a/src/MockConnection.php
+++ b/src/MockConnection.php
@@ -272,8 +272,8 @@ class MockConnection implements ConnectionInterface
 
     public function prettifyQuery($query, $params): string
     {
-        foreach ($params as $strParam) {
-            $query = preg_replace('/\?/', isset($strParam) ? '"' . $strParam . '"' : 'NULL', $query, 1);
+        foreach ($params as $param) {
+            $query = preg_replace('/\?/', isset($param) ? '"' . $param . '"' : 'NULL', $query, 1);
         }
 
         return $query;

--- a/src/MockConnection.php
+++ b/src/MockConnection.php
@@ -18,6 +18,8 @@ use Artemeon\Database\Schema\DataType;
 use Artemeon\Database\Schema\Table;
 use Artemeon\Database\Schema\TableIndex;
 
+use Generator;
+
 use function current;
 
 /**
@@ -60,12 +62,12 @@ class MockConnection implements ConnectionInterface
         $this->rows = [];
     }
 
-    public function getPArray($strQuery, $arrParams = [], $intStart = null, $intEnd = null, $bitCache = true, array $arrEscapes = []): array
+    public function getPArray($query, $params = [], $start = null, $end = null, $cache = true, array $escapes = []): array
     {
         return $this->rows;
     }
 
-    public function getPRow($strQuery, $arrParams = [], $intNr = 0, $bitCache = true, array $arrEscapes = []): array
+    public function getPRow($query, $params = [], $number = 0, $cache = true, array $escapes = []): array
     {
         return current($this->rows);
     }
@@ -75,7 +77,7 @@ class MockConnection implements ConnectionInterface
         return current($this->rows);
     }
 
-    public function getGenerator($query, array $params = [], $chunkSize = 2048, $paging = true)
+    public function getGenerator(string $query, array $params = [], int $chunkSize = 2048, bool $paging = true): Generator
     {
         yield from $this->rows;
     }
@@ -104,21 +106,21 @@ class MockConnection implements ConnectionInterface
         return null;
     }
 
-    public function iterateAssociative(string $query, array $params = []): \Generator
+    public function iterateAssociative(string $query, array $params = []): Generator
     {
         foreach ($this->rows as $row) {
             yield $row;
         }
     }
 
-    public function iterateColumn(string $query, array $params = []): \Generator
+    public function iterateColumn(string $query, array $params = []): Generator
     {
         foreach ($this->rows as $row) {
             yield reset($row);
         }
     }
 
-    public function _pQuery($strQuery, $arrParams = [], array $arrEscapes = []): bool
+    public function _pQuery($query, $params = [], array $escapes = []): bool
     {
         return true;
     }
@@ -128,7 +130,7 @@ class MockConnection implements ConnectionInterface
         return 1;
     }
 
-    public function getIntAffectedRows(): int
+    public function getAffectedRowsCount(): int
     {
         return 1;
     }
@@ -138,12 +140,12 @@ class MockConnection implements ConnectionInterface
         return 1;
     }
 
-    public function multiInsert(string $strTable, array $arrColumns, array $arrValueSets, ?array $arrEscapes = null): bool
+    public function multiInsert(string $tableName, array $columns, array $valueSets, ?array $escapes = null): bool
     {
         return true;
     }
 
-    public function insertOrUpdate($strTable, $arrColumns, $arrValues, $arrPrimaryColumns): bool
+    public function insertOrUpdate($tableName, $columns, $values, $primaryColumns): bool
     {
         return true;
     }
@@ -158,20 +160,20 @@ class MockConnection implements ConnectionInterface
         return 1;
     }
 
-    public function getBitConnected(): bool
+    public function isConnected(): bool
     {
         return true;
     }
 
-    public function transactionBegin(): void
+    public function beginTransaction(): void
     {
     }
 
-    public function transactionCommit(): void
+    public function commitTransaction(): void
     {
     }
 
-    public function transactionRollback(): void
+    public function rollbackTransaction(): void
     {
     }
 
@@ -190,12 +192,12 @@ class MockConnection implements ConnectionInterface
         throw new QueryException('not implemented', 'getTableInformation', []);
     }
 
-    public function getDatatype($strType): string
+    public function getDatatype(DataType $type): string
     {
-        return DataType::STR_TYPE_TEXT;
+        return DataType::TEXT->value;
     }
 
-    public function createTable($strName, $arrFields, $arrKeys, $arrIndices = array())
+    public function createTable(string $tableName, array $columns, array $keys, array $indices = []): bool
     {
         return true;
     }
@@ -208,7 +210,7 @@ class MockConnection implements ConnectionInterface
     {
     }
 
-    public function createIndex($strTable, $strName, array $arrColumns, $bitUnique = false)
+    public function createIndex(string $tableName, string $name, array $columns, bool $unique = false): bool
     {
         return true;
     }
@@ -218,68 +220,68 @@ class MockConnection implements ConnectionInterface
         return true;
     }
 
-    public function addIndex(string $table, TableIndex $index)
+    public function addIndex(string $table, TableIndex $index): bool
     {
         return true;
     }
 
-    public function hasIndex($strTable, $strName): bool
+    public function hasIndex($tableName, $name): bool
     {
         return true;
     }
 
-    public function renameTable($strOldName, $strNewName)
+    public function renameTable(string $oldName, string $newName): bool
     {
         return true;
     }
 
-    public function changeColumn($strTable, $strOldColumnName, $strNewColumnName, $strNewDatatype)
+    public function changeColumn(string $tableName, string $oldColumnName, string $newColumnName, DataType $newDataType): bool
     {
         return true;
     }
 
-    public function addColumn($strTable, $strColumn, $strDatatype, $bitNull = null, $strDefault = null)
+    public function addColumn(string $table, string $column, DataType $dataType, ?bool $nullable = null, ?string $default = null): bool
     {
         return true;
     }
 
-    public function removeColumn($strTable, $strColumn)
+    public function removeColumn(string $tableName, string $column): bool
     {
         return true;
     }
 
-    public function hasColumn($strTable, $strColumn): bool
+    public function hasColumn(string $tableName, string $column): bool
     {
         return true;
     }
 
-    public function hasTable($strTable): bool
+    public function hasTable($tableName): bool
     {
         return true;
     }
 
-    public function encloseColumnName($strColumn): string
+    public function encloseColumnName($column): string
     {
-        return $strColumn;
+        return $column;
     }
 
-    public function encloseTableName($strTable): string
+    public function encloseTableName($tableName): string
     {
-        return $strTable;
+        return $tableName;
     }
 
-    public function prettifyQuery($strQuery, $arrParams): string
+    public function prettifyQuery($query, $params): string
     {
-        foreach ($arrParams as $strParam) {
-            $strQuery = preg_replace('/\?/', isset($strParam) ? '"' . $strParam . '"' : 'NULL', $strQuery, 1);
+        foreach ($params as $strParam) {
+            $query = preg_replace('/\?/', isset($strParam) ? '"' . $strParam . '"' : 'NULL', $query, 1);
         }
 
-        return $strQuery;
+        return $query;
     }
 
-    public function appendLimitExpression($strQuery, $intStart, $intEnd): string
+    public function appendLimitExpression($query, $start, $end): string
     {
-        return $strQuery . ' LIMIT ' . $intStart . ',' . ($intEnd - $intStart + 1);
+        return $query . ' LIMIT ' . $start . ',' . ($end - $start + 1);
     }
 
     public function getConcatExpression(array $parts): string
@@ -307,7 +309,7 @@ class MockConnection implements ConnectionInterface
         return 'LENGTH(' . $targetString . ')';
     }
 
-    public function convertToDatabaseValue($value, string $type): string
+    public function convertToDatabaseValue(mixed $value, DataType $type): string
     {
         return (string) $value;
     }

--- a/src/Schema/DataType.php
+++ b/src/Schema/DataType.php
@@ -15,32 +15,17 @@ namespace Artemeon\Database\Schema;
 
 /**
  * List of possible data-types usable when generating new tables / updating tables.
- *
- * @package module_system
- * @author sidler@mulchprod.de
- * @since 4.5
  */
-class DataType
+enum DataType: string
 {
-    const STR_TYPE_INT = "int";
-
-    const STR_TYPE_BIGINT = "long";
-    /**
-     * @deprecated please use bigint
-     */
-    const STR_TYPE_LONG = "long";
-
-    const STR_TYPE_FLOAT = "double";
-    /**
-     * @deprecated please use float
-     */
-    const STR_TYPE_DOUBLE = "double";
-
-    const STR_TYPE_CHAR10 = "char10";
-    const STR_TYPE_CHAR20 = "char20";
-    const STR_TYPE_CHAR100 = "char100";
-    const STR_TYPE_CHAR254 = "char254";
-    const STR_TYPE_CHAR500 = "char500";
-    const STR_TYPE_TEXT = "text";
-    const STR_TYPE_LONGTEXT = "longtext";
+    case INT = 'int';
+    case BIGINT = 'long';
+    case FLOAT = 'double';
+    case CHAR10 = 'char10';
+    case CHAR20 = 'char20';
+    case CHAR100 = 'char100';
+    case CHAR254 = 'char254';
+    case CHAR500 = 'char500';
+    case TEXT = 'text';
+    case LONGTEXT = 'longtext';
 }

--- a/src/Schema/Table.php
+++ b/src/Schema/Table.php
@@ -13,28 +13,24 @@ declare(strict_types=1);
 
 namespace Artemeon\Database\Schema;
 
+use JsonSerializable;
+
 /**
- * Base information about a database table
- * @package Kajona\System\System\Db\Schema
- * @author stefan.idler@artemeon.de
+ * Base information about a database table.
  */
-class Table implements \JsonSerializable
+class Table implements JsonSerializable
 {
-    private $name = "";
+    private string $name;
 
     /** @var TableColumn[] */
-    private $columns = [];
+    private array $columns = [];
 
     /** @var TableIndex[] */
-    private $indexes = [];
+    private array $indexes = [];
 
     /** @var TableKey[] */
-    private $primaryKeys = [];
+    private array $primaryKeys = [];
 
-    /**
-     * Table constructor.
-     * @param string $name
-     */
     public function __construct(string $name)
     {
         $this->name = $name;
@@ -46,67 +42,58 @@ class Table implements \JsonSerializable
     public function jsonSerialize(): array
     {
         return [
-            "name" => $this->getName(),
-            "indexes" => $this->getIndexes(),
-            "keys" => $this->getPrimaryKeys(),
-            "columns" => $this->getColumns()
+            'name' => $this->getName(),
+            'indexes' => $this->getIndexes(),
+            'keys' => $this->getPrimaryKeys(),
+            'columns' => $this->getColumns(),
         ];
     }
 
     /**
-     * Fetches a single table col info
-     * @param $name
-     * @return TableColumn|null
+     * Fetches a single table col info.
      */
-    public function getColumnByName($name): ?TableColumn
+    public function getColumnByName(string $name): ?TableColumn
     {
         foreach ($this->columns as $col) {
-            if ($col->getName() == $name) {
+            if ($col->getName() === $name) {
                 return $col;
             }
         }
+
         return null;
     }
 
-
-    /**
-     * @param TableColumn $col
-     */
-    public function addColumn(TableColumn $col)
+    public function addColumn(TableColumn $column): self
     {
-        $this->columns[] = $col;
+        $this->columns[] = $column;
+
+        return $this;
     }
 
-    /**
-     * @param TableIndex $index
-     */
-    public function addIndex(TableIndex $index)
+    public function addIndex(TableIndex $index): self
     {
         $this->indexes[] = $index;
+
+        return $this;
     }
 
-    /**
-     * @param TableKey $key
-     */
-    public function addPrimaryKey(TableKey $key)
+    public function addPrimaryKey(TableKey $key): self
     {
         $this->primaryKeys[] = $key;
+
+        return $this;
     }
 
-    /**
-     * @return string
-     */
     public function getName(): string
     {
         return $this->name;
     }
 
-    /**
-     * @param string $name
-     */
-    public function setName(string $name)
+    public function setName(string $name): self
     {
         $this->name = $name;
+
+        return $this;
     }
 
     /**
@@ -120,9 +107,11 @@ class Table implements \JsonSerializable
     /**
      * @param TableColumn[] $columns
      */
-    public function setColumns(array $columns)
+    public function setColumns(array $columns): self
     {
         $this->columns = $columns;
+
+        return $this;
     }
 
     /**
@@ -136,9 +125,11 @@ class Table implements \JsonSerializable
     /**
      * @param TableIndex[] $indexes
      */
-    public function setIndexes(array $indexes)
+    public function setIndexes(array $indexes): self
     {
         $this->indexes = $indexes;
+
+        return $this;
     }
 
     /**
@@ -152,18 +143,15 @@ class Table implements \JsonSerializable
     /**
      * @param TableKey[] $primaryKeys
      */
-    public function setPrimaryKeys(array $primaryKeys)
+    public function setPrimaryKeys(array $primaryKeys): self
     {
         $this->primaryKeys = $primaryKeys;
+
+        return $this;
     }
 
-    /**
-     * @return array
-     */
     public function getColumnNames(): array
     {
-        return array_map(function(TableColumn $column){
-            return $column->getName();
-        }, $this->columns);
+        return array_map(static fn (TableColumn $column) => $column->getName(), $this->columns);
     }
 }

--- a/src/Schema/TableColumn.php
+++ b/src/Schema/TableColumn.php
@@ -13,22 +13,23 @@ declare(strict_types=1);
 
 namespace Artemeon\Database\Schema;
 
-/**
- * Base information about a tables column
- * @package Kajona\System\System\Db\Schema
- * @author stefan.idler@artemeon.de
- */
-class TableColumn implements \JsonSerializable
-{
-    private $name = "";
-    private $internalType = "";
-    private $databaseType = "";
-    private $nullable = true;
+use JsonSerializable;
 
-    /**
-     * TableColumn constructor.
-     * @param string $name
-     */
+/**
+ * Base information about a table's column.
+ */
+class TableColumn implements JsonSerializable
+{
+    private string $name;
+    private ?DataType $internalType = null;
+    private string $databaseType = '';
+    private bool $nullable = true;
+
+    public static function make(string $name): self
+    {
+        return new self($name);
+    }
+
     public function __construct(string $name)
     {
         $this->name = $name;
@@ -40,79 +41,58 @@ class TableColumn implements \JsonSerializable
     public function jsonSerialize(): array
     {
         return [
-            "name" => $this->getName(),
-            "internalType" => $this->getInternalType(),
-            "databaseType" => $this->getDatabaseType(),
-            "nullable" => $this->isNullable()
+            'name' => $this->getName(),
+            'internalType' => $this->getInternalType()?->value ?? '',
+            'databaseType' => $this->getDatabaseType(),
+            'nullable' => $this->isNullable(),
         ];
     }
 
-    /**
-     * @return bool
-     */
     public function isNullable(): bool
     {
         return $this->nullable;
     }
 
-    /**
-     * @param bool $nullable
-     */
-    public function setNullable(bool $nullable)
+    public function setNullable(bool $nullable): self
     {
         $this->nullable = $nullable;
+
+        return $this;
     }
 
-
-
-
-    /**
-     * @return string
-     */
     public function getName(): string
     {
         return $this->name;
     }
 
-    /**
-     * @param string $name
-     */
-    public function setName(string $name)
+    public function setName(string $name): self
     {
         $this->name = $name;
+
+        return $this;
     }
 
-    /**
-     * @return string
-     */
-    public function getInternalType(): string
+    public function getInternalType(): ?DataType
     {
         return $this->internalType;
     }
 
-    /**
-     * @param string $internalType
-     */
-    public function setInternalType(string $internalType)
+    public function setInternalType(?DataType $internalType): self
     {
         $this->internalType = $internalType;
+
+        return $this;
     }
 
-    /**
-     * @return string
-     */
     public function getDatabaseType(): string
     {
         return $this->databaseType;
     }
 
-    /**
-     * @param string $databaseType
-     */
-    public function setDatabaseType(string $databaseType)
+    public function setDatabaseType(string $databaseType): self
     {
         $this->databaseType = $databaseType;
+
+        return $this;
     }
-
-
 }

--- a/src/Schema/TableIndex.php
+++ b/src/Schema/TableIndex.php
@@ -13,20 +13,16 @@ declare(strict_types=1);
 
 namespace Artemeon\Database\Schema;
 
-/**
- * Base information about a tables index
- * @package Kajona\System\System\Db\Schema
- * @author stefan.idler@artemeon.de
- */
-class TableIndex implements \JsonSerializable
-{
-    private $name = "";
-    private $description = "";
+use JsonSerializable;
 
-    /**
-     * TableIndex constructor.
-     * @param string $name
-     */
+/**
+ * Base information about a table's index.
+ */
+class TableIndex implements JsonSerializable
+{
+    private string $name;
+    private string $description = '';
+
     public function __construct(string $name)
     {
         $this->name = $name;
@@ -38,46 +34,32 @@ class TableIndex implements \JsonSerializable
     public function jsonSerialize(): array
     {
         return [
-            "name" => $this->getName(),
-            "description" => $this->getDescription()
+            'name' => $this->getName(),
+            'description' => $this->getDescription(),
         ];
     }
 
-
-    /**
-     * @return string
-     */
     public function getName(): string
     {
         return $this->name;
     }
 
-    /**
-     * @param string $name
-     */
-    public function setName(string $name)
+    public function setName(string $name): self
     {
         $this->name = $name;
+
         return $this;
     }
 
-    /**
-     * @return string
-     */
     public function getDescription(): string
     {
         return $this->description;
     }
 
-    /**
-     * @param string $description
-     */
-    public function setDescription(string $description)
+    public function setDescription(string $description): self
     {
         $this->description = $description;
+
         return $this;
     }
-
-
-
 }

--- a/src/Schema/TableKey.php
+++ b/src/Schema/TableKey.php
@@ -13,19 +13,15 @@ declare(strict_types=1);
 
 namespace Artemeon\Database\Schema;
 
+use JsonSerializable;
+
 /**
  * Base information about a tables primary key
- * @package Kajona\System\System\Db\Schema
- * @author stefan.idler@artemeon.de
  */
-class TableKey implements \JsonSerializable
+class TableKey implements JsonSerializable
 {
-    private $name = "";
+    private string $name;
 
-    /**
-     * TableKey constructor.
-     * @param string $name
-     */
     public function __construct(string $name)
     {
         $this->name = $name;
@@ -36,26 +32,18 @@ class TableKey implements \JsonSerializable
      */
     public function jsonSerialize(): array
     {
-        return ["name" => $this->getName()];
+        return ['name' => $this->getName()];
     }
 
-
-    /**
-     * @return string
-     */
     public function getName(): string
     {
         return $this->name;
     }
 
-    /**
-     * @param string $name
-     */
-    public function setName(string $name)
+    public function setName(string $name): self
     {
         $this->name = $name;
+
+        return $this;
     }
-
-
-
 }

--- a/tests/ConnectionColumnTypeTest.php
+++ b/tests/ConnectionColumnTypeTest.php
@@ -13,9 +13,18 @@ declare(strict_types=1);
 
 namespace Artemeon\Database\Tests;
 
+use Artemeon\Database\Exception\ConnectionException;
+use Artemeon\Database\Exception\QueryException;
+use Artemeon\Database\Exception\TableNotFoundException;
+
 class ConnectionColumnTypeTest extends ConnectionTestCase
 {
-    public function testTypeConversion()
+    /**
+     * @throws QueryException
+     * @throws ConnectionException
+     * @throws TableNotFoundException
+     */
+    public function testTypeConversion(): void
     {
         $connection = $this->getConnection();
         $columns = $this->getTestTableColumns();
@@ -24,11 +33,10 @@ class ConnectionColumnTypeTest extends ConnectionTestCase
         $columnsFromDb = $connection->getColumnsOfTable(self::TEST_TABLE_NAME);
 
         foreach ($columnsFromDb as $columnName => $details) {
-
-            //compare both internal types converted to db-based types, those need to match
+            // compare both internal types converted to db-based types, those need to match.
             $this->assertEquals(
-                $this->getConnection()->getDatatype(trim($columns[$columnName][0])),
-                $this->getConnection()->getDatatype(trim($details["columnType"]))
+                $this->getConnection()->getDatatype($columns[$columnName][0]),
+                $this->getConnection()->getDatatype($details['columnType']),
             );
         }
     }

--- a/tests/ConnectionMultiInsertTest.php
+++ b/tests/ConnectionMultiInsertTest.php
@@ -13,17 +13,28 @@ declare(strict_types=1);
 
 namespace Artemeon\Database\Tests;
 
+use Artemeon\Database\Exception\ConnectionException;
+use Artemeon\Database\Exception\QueryException;
+
 class ConnectionMultiInsertTest extends ConnectionTestCase
 {
+    /**
+     * @throws ConnectionException
+     * @throws QueryException
+     */
     protected function setUp(): void
     {
         parent::setUp();
 
-        $this->getConnection()->_pQuery('DELETE FROM ' . self::TEST_TABLE_NAME . ' WHERE 1=1', []);
+        $this->getConnection()->_pQuery('DELETE FROM ' . self::TEST_TABLE_NAME . ' WHERE 1=1');
         $this->getConnection()->flushQueryCache();
     }
 
-    public function testInserts()
+    /**
+     * @throws ConnectionException
+     * @throws QueryException
+     */
+    public function testInserts(): void
     {
         $values = $this->getRows(50, false);
         $connection = $this->getConnection();
@@ -31,26 +42,30 @@ class ConnectionMultiInsertTest extends ConnectionTestCase
         $return = $connection->multiInsert(self::TEST_TABLE_NAME, $this->getColumnNames(), $values);
         $this->assertTrue($return);
 
-        $row = $connection->getPRow("SELECT COUNT(*) AS cnt FROM " . self::TEST_TABLE_NAME, []);
-        $this->assertEquals($row['cnt'], 50);
+        $row = $connection->getPRow('SELECT COUNT(*) AS cnt FROM ' . self::TEST_TABLE_NAME);
+        $this->assertEquals(50, $row['cnt']);
 
         for ($i = 1; $i <= 50; $i++) {
-            $row = $connection->getPRow("SELECT * FROM " . self::TEST_TABLE_NAME . " WHERE temp_int = ?", [123456 + $i]);
+            $row = $connection->getPRow('SELECT * FROM ' . self::TEST_TABLE_NAME . ' WHERE temp_int = ?', [123456 + $i]);
 
-            $this->assertEquals(123456 + $i, $row["temp_int"]);
-            $this->assertEquals(20200508095300 + $i, $row["temp_bigint"]);
-            $this->assertEquals(23.45, round((float) $row["temp_float"], 2));
-            $this->assertEquals("char10-" . $i, $row["temp_char10"]);
-            $this->assertEquals("char20-" . $i, $row["temp_char20"]);
-            $this->assertEquals("char100-" . $i, $row["temp_char100"]);
-            $this->assertEquals("char254-" . $i, $row["temp_char254"]);
-            $this->assertEquals("char500-" . $i, $row["temp_char500"]);
-            $this->assertEquals("text-" . $i, $row["temp_text"]);
-            $this->assertEquals("longtext-" . $i, $row["temp_longtext"]);
+            $this->assertEquals(123456 + $i, $row['temp_int']);
+            $this->assertEquals(20200508095300 + $i, $row['temp_bigint']);
+            $this->assertEquals(23.45, round((float) $row['temp_float'], 2));
+            $this->assertEquals('char10-' . $i, $row['temp_char10']);
+            $this->assertEquals('char20-' . $i, $row['temp_char20']);
+            $this->assertEquals('char100-' . $i, $row['temp_char100']);
+            $this->assertEquals('char254-' . $i, $row['temp_char254']);
+            $this->assertEquals('char500-' . $i, $row['temp_char500']);
+            $this->assertEquals('text-' . $i, $row['temp_text']);
+            $this->assertEquals('longtext-' . $i, $row['temp_longtext']);
         }
     }
 
-    public function testInsertsLimit()
+    /**
+     * @throws QueryException
+     * @throws ConnectionException
+     */
+    public function testInsertsLimit(): void
     {
         $values = $this->getRows(1000, false);
         $connection = $this->getConnection();
@@ -58,7 +73,7 @@ class ConnectionMultiInsertTest extends ConnectionTestCase
         $return = $connection->multiInsert(self::TEST_TABLE_NAME, $this->getColumnNames(), $values);
         $this->assertTrue($return);
 
-        $arrRow = $connection->getPRow("SELECT COUNT(*) AS cnt FROM " . self::TEST_TABLE_NAME, []);
-        $this->assertEquals($arrRow["cnt"], 1000);
+        $arrRow = $connection->getPRow('SELECT COUNT(*) AS cnt FROM ' . self::TEST_TABLE_NAME);
+        $this->assertEquals(1000, $arrRow['cnt']);
     }
 }

--- a/tests/ConnectionMultiInsertTest.php
+++ b/tests/ConnectionMultiInsertTest.php
@@ -73,7 +73,7 @@ class ConnectionMultiInsertTest extends ConnectionTestCase
         $return = $connection->multiInsert(self::TEST_TABLE_NAME, $this->getColumnNames(), $values);
         $this->assertTrue($return);
 
-        $arrRow = $connection->getPRow('SELECT COUNT(*) AS cnt FROM ' . self::TEST_TABLE_NAME);
-        $this->assertEquals(1000, $arrRow['cnt']);
+        $row = $connection->getPRow('SELECT COUNT(*) AS cnt FROM ' . self::TEST_TABLE_NAME);
+        $this->assertEquals(1000, $row['cnt']);
     }
 }

--- a/tests/ConnectionPreparedTest.php
+++ b/tests/ConnectionPreparedTest.php
@@ -13,105 +13,115 @@ declare(strict_types=1);
 
 namespace Artemeon\Database\Tests;
 
+use Artemeon\Database\Exception\ConnectionException;
+use Artemeon\Database\Exception\QueryException;
+use Artemeon\Database\Schema\DataType;
+
 class ConnectionPreparedTest extends ConnectionTestCase
 {
-    public function test()
+    /**
+     * @throws ConnectionException
+     * @throws QueryException
+     */
+    public function test(): void
     {
         $connection = $this->getConnection();
 
+        $strQuery = 'SELECT * FROM ' . self::TEST_TABLE_NAME . ' ORDER BY temp_bigint ASC';
+        $arrRow = $connection->getPRow($strQuery);
+        $this->assertTrue(count($arrRow) >= 9, 'testDataBase getRow count');
+        $this->assertEquals('char10-1', $arrRow['temp_char10'], 'testDataBase getRow content');
 
-        $strQuery = "SELECT * FROM " . self::TEST_TABLE_NAME . " ORDER BY temp_bigint ASC";
-        $arrRow = $connection->getPRow($strQuery, array());
-        $this->assertTrue(count($arrRow) >= 9, "testDataBase getRow count");
-        $this->assertEquals($arrRow["temp_char10"], "char10-1", "testDataBase getRow content");
 
+        $strQuery = 'SELECT * FROM ' . self::TEST_TABLE_NAME . ' WHERE temp_char10 = ? ORDER BY temp_bigint ASC';
+        $arrRow = $connection->getPRow($strQuery, ['char10-2']);
+        $this->assertTrue(count($arrRow) >= 9, 'testDataBase getRow count');
+        $this->assertEquals('char10-2', $arrRow['temp_char10'], 'testDataBase getRow content');
 
-        $strQuery = "SELECT * FROM " . self::TEST_TABLE_NAME . " WHERE temp_char10 = ? ORDER BY temp_bigint ASC";
-        $arrRow = $connection->getPRow($strQuery, array('char10-2'));
-        $this->assertTrue(count($arrRow) >= 9, "testDataBase getRow count");
-        $this->assertEquals($arrRow["temp_char10"], "char10-2", "testDataBase getRow content");
-
-        $strQuery = "SELECT * FROM " . self::TEST_TABLE_NAME . " ORDER BY temp_bigint ASC";
-        $arrRow = $connection->getPArray($strQuery, array());
-        $this->assertEquals(count($arrRow), 50, "testDataBase getArray count");
-
-        $intI = 1;
-        foreach ($arrRow as $arrSingleRow)
-            $this->assertEquals($arrSingleRow["temp_char10"], 'char10-' . $intI++, "testDataBase getArray content");
-
-        $strQuery = "SELECT * FROM " . self::TEST_TABLE_NAME . " WHERE temp_char10 = ? ORDER BY temp_bigint ASC";
-        $arrRow = $connection->getPArray($strQuery, array('char10-2'));
-        $this->assertEquals(count($arrRow), 1, "testDataBase getArray count");
-
-        $strQuery = "SELECT * FROM " . self::TEST_TABLE_NAME . " ORDER BY temp_bigint ASC";
-        $arrRow = $connection->getPArray($strQuery, array(), 0, 9);
-        $this->assertEquals(count($arrRow), 10, "testDataBase getArraySection count");
-        $this->assertEquals($arrRow[0]["temp_char10"], 'char10-1');
-        $this->assertEquals($arrRow[9]["temp_char10"], 'char10-10');
+        $strQuery = 'SELECT * FROM ' . self::TEST_TABLE_NAME . ' ORDER BY temp_bigint ASC';
+        $arrRow = $connection->getPArray($strQuery);
+        $this->assertCount(50, $arrRow, 'testDataBase getArray count');
 
         $intI = 1;
         foreach ($arrRow as $arrSingleRow) {
-            $this->assertEquals($arrSingleRow["temp_char10"], 'char10-' . $intI++, "testDataBase getArraySection content");
+            $this->assertEquals('char10-' . $intI++, $arrSingleRow['temp_char10'], 'testDataBase getArray content');
         }
 
+        $strQuery = 'SELECT * FROM ' . self::TEST_TABLE_NAME . ' WHERE temp_char10 = ? ORDER BY temp_bigint ASC';
+        $arrRow = $connection->getPArray($strQuery, ['char10-2']);
+        $this->assertCount(1, $arrRow, 'testDataBase getArray count');
 
-        $strQuery = "SELECT * FROM " . self::TEST_TABLE_NAME . " ORDER BY temp_bigint ASC";
-        $arrRow = $connection->getPArray($strQuery, array(), 5, 14);
-        $this->assertEquals(count($arrRow), 10, "testDataBase getArraySection offset count");
-        $this->assertEquals($arrRow[0]["temp_char10"], 'char10-6');
-        $this->assertEquals($arrRow[9]["temp_char10"], 'char10-15');
+        $strQuery = 'SELECT * FROM ' . self::TEST_TABLE_NAME . ' ORDER BY temp_bigint ASC';
+        $arrRow = $connection->getPArray($strQuery, [], 0, 9);
+        $this->assertCount(10, $arrRow, 'testDataBase getArraySection count');
+        $this->assertEquals('char10-1', $arrRow[0]['temp_char10']);
+        $this->assertEquals('char10-10', $arrRow[9]['temp_char10']);
 
+        $intI = 1;
+        foreach ($arrRow as $arrSingleRow) {
+            $this->assertEquals('char10-' . $intI++, $arrSingleRow['temp_char10'], 'testDataBase getArraySection content');
+        }
+
+        $strQuery = 'SELECT * FROM ' . self::TEST_TABLE_NAME . ' ORDER BY temp_bigint ASC';
+        $arrRow = $connection->getPArray($strQuery, [], 5, 14);
+        $this->assertCount(10, $arrRow, 'testDataBase getArraySection offset count');
+        $this->assertEquals('char10-6', $arrRow[0]['temp_char10']);
+        $this->assertEquals('char10-15', $arrRow[9]['temp_char10']);
 
         $this->flushDBCache();
-        $strQuery = "SELECT * FROM " . self::TEST_TABLE_NAME . " WHERE temp_char10 LIKE ? ORDER BY temp_bigint ASC";
-        $arrRow = $connection->getPArray($strQuery, array("%"), 0, 9);
-        $this->assertEquals(count($arrRow), 10, "testDataBase getArraySection param count");
+        $strQuery = 'SELECT * FROM ' . self::TEST_TABLE_NAME . ' WHERE temp_char10 LIKE ? ORDER BY temp_bigint ASC';
+        $arrRow = $connection->getPArray($strQuery, ['%'], 0, 9);
+        $this->assertCount(10, $arrRow, 'testDataBase getArraySection param count');
 
         $intI = 1;
         foreach ($arrRow as $arrSingleRow) {
-            $this->assertEquals($arrSingleRow["temp_char10"], 'char10-' . $intI++, "testDataBase getArraySection param content");
+            $this->assertEquals('char10-' . $intI++, $arrSingleRow['temp_char10'], 'testDataBase getArraySection param content');
         }
 
-        $strQuery = "SELECT * FROM " . self::TEST_TABLE_NAME . "  WHERE temp_char10 = ? AND temp_char20 = ? ORDER BY temp_bigint ASC";
-        $arrRow = $connection->getPArray($strQuery, array('char10-2', 'char202'));
-        $this->assertEquals(count($arrRow), 0, "testDataBase getArray 2 params count");
+        $strQuery = 'SELECT * FROM ' . self::TEST_TABLE_NAME . '  WHERE temp_char10 = ? AND temp_char20 = ? ORDER BY temp_bigint ASC';
+        $arrRow = $connection->getPArray($strQuery, ['char10-2', 'char202']);
+        $this->assertCount(0, $arrRow, 'testDataBase getArray 2 params count');
 
-        $strQuery = "SELECT * FROM " . self::TEST_TABLE_NAME . "  WHERE temp_char10 = ? AND temp_char20 = ? ORDER BY temp_bigint ASC";
-        $arrRow = $connection->getPArray($strQuery, array('2', null));
-        $this->assertEquals(count($arrRow), 0, "testDataBase getArray 2 params count");
-        
-        $strQuery = "DROP TABLE " . self::TEST_TABLE_NAME;
-        $this->assertTrue($connection->_pQuery($strQuery, array()), "testDataBase dropTable");
+        $strQuery = 'SELECT * FROM ' . self::TEST_TABLE_NAME . '  WHERE temp_char10 = ? AND temp_char20 = ? ORDER BY temp_bigint ASC';
+        $arrRow = $connection->getPArray($strQuery, ['2', null]);
+        $this->assertCount(0, $arrRow, 'testDataBase getArray 2 params count');
+
+        $strQuery = 'DROP TABLE ' . self::TEST_TABLE_NAME;
+        $this->assertTrue($connection->_pQuery($strQuery), 'testDataBase dropTable');
     }
 
-    public function testFloatHandling()
+    /**
+     * @throws QueryException
+     * @throws ConnectionException
+     */
+    public function testFloatHandling(): void
     {
         $connection = $this->getConnection();
 
-        $arrFields = array();
-        $arrFields["temp_id"] = array("char20", false);
-        $arrFields["temp_long"] = array("long", true);
-        $arrFields["temp_double"] = array("double", true);
+        $arrFields = [];
+        $arrFields['temp_id'] = [DataType::CHAR20, false];
+        $arrFields['temp_long'] = [DataType::BIGINT, true];
+        $arrFields['temp_double'] = [DataType::FLOAT, true];
 
-        $this->assertTrue($connection->createTable("agp_temp_autotest_float", $arrFields, array("temp_id")), "testDataBase createTable");
+        $this->assertTrue($connection->createTable('agp_temp_autotest_float', $arrFields, ['temp_id']), 'testDataBase createTable');
 
-        $connection->_pQuery("DELETE FROM " . self::TEST_TABLE_NAME . " WHERE 1 = 1", array());
+        $connection->_pQuery('DELETE FROM ' . self::TEST_TABLE_NAME . ' WHERE 1 = 1');
 
         $connection->multiInsert(
             self::TEST_TABLE_NAME,
-            array("temp_id", "temp_bigint", "temp_float"),
-            array(array("id1", 123456, 1.7), array("id2", "123456", "1.7"))
+            ['temp_id', 'temp_bigint', 'temp_float'],
+            [['id1', 123456, 1.7], ['id2', '123456', '1.7']]
         );
 
-        $arrRow = $connection->getPRow("SELECT * FROM " . self::TEST_TABLE_NAME . " WHERE temp_id = ?", array("id1"));
+        $arrRow = $connection->getPRow('SELECT * FROM ' . self::TEST_TABLE_NAME . ' WHERE temp_id = ?', ['id1']);
 
-        $this->assertEquals(123456, $arrRow["temp_bigint"]);
-        $this->assertEquals(1.7, round((float) $arrRow["temp_float"], 1));
+        $this->assertEquals(123456, $arrRow['temp_bigint']);
+        $this->assertEquals(1.7, round((float) $arrRow['temp_float'], 1));
 
-        $arrRow = $connection->getPRow("SELECT * FROM " . self::TEST_TABLE_NAME . " WHERE temp_id = ?", array("id2"));
+        $arrRow = $connection->getPRow('SELECT * FROM ' . self::TEST_TABLE_NAME . ' WHERE temp_id = ?', ['id2']);
 
-        $this->assertEquals(123456, $arrRow["temp_bigint"]);
-        $this->assertEquals(1.7, round((float) $arrRow["temp_float"], 1));
+        $this->assertEquals(123456, $arrRow['temp_bigint']);
+        $this->assertEquals(1.7, round((float) $arrRow['temp_float'], 1));
     }
 }
 

--- a/tests/ConnectionPreparedTest.php
+++ b/tests/ConnectionPreparedTest.php
@@ -27,67 +27,67 @@ class ConnectionPreparedTest extends ConnectionTestCase
     {
         $connection = $this->getConnection();
 
-        $strQuery = 'SELECT * FROM ' . self::TEST_TABLE_NAME . ' ORDER BY temp_bigint ASC';
-        $arrRow = $connection->getPRow($strQuery);
-        $this->assertTrue(count($arrRow) >= 9, 'testDataBase getRow count');
-        $this->assertEquals('char10-1', $arrRow['temp_char10'], 'testDataBase getRow content');
+        $query = 'SELECT * FROM ' . self::TEST_TABLE_NAME . ' ORDER BY temp_bigint ASC';
+        $row = $connection->getPRow($query);
+        $this->assertTrue(count($row) >= 9, 'testDataBase getRow count');
+        $this->assertEquals('char10-1', $row['temp_char10'], 'testDataBase getRow content');
 
 
-        $strQuery = 'SELECT * FROM ' . self::TEST_TABLE_NAME . ' WHERE temp_char10 = ? ORDER BY temp_bigint ASC';
-        $arrRow = $connection->getPRow($strQuery, ['char10-2']);
-        $this->assertTrue(count($arrRow) >= 9, 'testDataBase getRow count');
-        $this->assertEquals('char10-2', $arrRow['temp_char10'], 'testDataBase getRow content');
+        $query = 'SELECT * FROM ' . self::TEST_TABLE_NAME . ' WHERE temp_char10 = ? ORDER BY temp_bigint ASC';
+        $row = $connection->getPRow($query, ['char10-2']);
+        $this->assertTrue(count($row) >= 9, 'testDataBase getRow count');
+        $this->assertEquals('char10-2', $row['temp_char10'], 'testDataBase getRow content');
 
-        $strQuery = 'SELECT * FROM ' . self::TEST_TABLE_NAME . ' ORDER BY temp_bigint ASC';
-        $arrRow = $connection->getPArray($strQuery);
-        $this->assertCount(50, $arrRow, 'testDataBase getArray count');
+        $query = 'SELECT * FROM ' . self::TEST_TABLE_NAME . ' ORDER BY temp_bigint ASC';
+        $row = $connection->getPArray($query);
+        $this->assertCount(50, $row, 'testDataBase getArray count');
 
-        $intI = 1;
-        foreach ($arrRow as $arrSingleRow) {
-            $this->assertEquals('char10-' . $intI++, $arrSingleRow['temp_char10'], 'testDataBase getArray content');
+        $i = 1;
+        foreach ($row as $singleRow) {
+            $this->assertEquals('char10-' . $i++, $singleRow['temp_char10'], 'testDataBase getArray content');
         }
 
-        $strQuery = 'SELECT * FROM ' . self::TEST_TABLE_NAME . ' WHERE temp_char10 = ? ORDER BY temp_bigint ASC';
-        $arrRow = $connection->getPArray($strQuery, ['char10-2']);
-        $this->assertCount(1, $arrRow, 'testDataBase getArray count');
+        $query = 'SELECT * FROM ' . self::TEST_TABLE_NAME . ' WHERE temp_char10 = ? ORDER BY temp_bigint ASC';
+        $row = $connection->getPArray($query, ['char10-2']);
+        $this->assertCount(1, $row, 'testDataBase getArray count');
 
-        $strQuery = 'SELECT * FROM ' . self::TEST_TABLE_NAME . ' ORDER BY temp_bigint ASC';
-        $arrRow = $connection->getPArray($strQuery, [], 0, 9);
-        $this->assertCount(10, $arrRow, 'testDataBase getArraySection count');
-        $this->assertEquals('char10-1', $arrRow[0]['temp_char10']);
-        $this->assertEquals('char10-10', $arrRow[9]['temp_char10']);
+        $query = 'SELECT * FROM ' . self::TEST_TABLE_NAME . ' ORDER BY temp_bigint ASC';
+        $row = $connection->getPArray($query, [], 0, 9);
+        $this->assertCount(10, $row, 'testDataBase getArraySection count');
+        $this->assertEquals('char10-1', $row[0]['temp_char10']);
+        $this->assertEquals('char10-10', $row[9]['temp_char10']);
 
-        $intI = 1;
-        foreach ($arrRow as $arrSingleRow) {
-            $this->assertEquals('char10-' . $intI++, $arrSingleRow['temp_char10'], 'testDataBase getArraySection content');
+        $i = 1;
+        foreach ($row as $singleRow) {
+            $this->assertEquals('char10-' . $i++, $singleRow['temp_char10'], 'testDataBase getArraySection content');
         }
 
-        $strQuery = 'SELECT * FROM ' . self::TEST_TABLE_NAME . ' ORDER BY temp_bigint ASC';
-        $arrRow = $connection->getPArray($strQuery, [], 5, 14);
-        $this->assertCount(10, $arrRow, 'testDataBase getArraySection offset count');
-        $this->assertEquals('char10-6', $arrRow[0]['temp_char10']);
-        $this->assertEquals('char10-15', $arrRow[9]['temp_char10']);
+        $query = 'SELECT * FROM ' . self::TEST_TABLE_NAME . ' ORDER BY temp_bigint ASC';
+        $row = $connection->getPArray($query, [], 5, 14);
+        $this->assertCount(10, $row, 'testDataBase getArraySection offset count');
+        $this->assertEquals('char10-6', $row[0]['temp_char10']);
+        $this->assertEquals('char10-15', $row[9]['temp_char10']);
 
         $this->flushDBCache();
-        $strQuery = 'SELECT * FROM ' . self::TEST_TABLE_NAME . ' WHERE temp_char10 LIKE ? ORDER BY temp_bigint ASC';
-        $arrRow = $connection->getPArray($strQuery, ['%'], 0, 9);
-        $this->assertCount(10, $arrRow, 'testDataBase getArraySection param count');
+        $query = 'SELECT * FROM ' . self::TEST_TABLE_NAME . ' WHERE temp_char10 LIKE ? ORDER BY temp_bigint ASC';
+        $row = $connection->getPArray($query, ['%'], 0, 9);
+        $this->assertCount(10, $row, 'testDataBase getArraySection param count');
 
-        $intI = 1;
-        foreach ($arrRow as $arrSingleRow) {
-            $this->assertEquals('char10-' . $intI++, $arrSingleRow['temp_char10'], 'testDataBase getArraySection param content');
+        $i = 1;
+        foreach ($row as $singleRow) {
+            $this->assertEquals('char10-' . $i++, $singleRow['temp_char10'], 'testDataBase getArraySection param content');
         }
 
-        $strQuery = 'SELECT * FROM ' . self::TEST_TABLE_NAME . '  WHERE temp_char10 = ? AND temp_char20 = ? ORDER BY temp_bigint ASC';
-        $arrRow = $connection->getPArray($strQuery, ['char10-2', 'char202']);
-        $this->assertCount(0, $arrRow, 'testDataBase getArray 2 params count');
+        $query = 'SELECT * FROM ' . self::TEST_TABLE_NAME . '  WHERE temp_char10 = ? AND temp_char20 = ? ORDER BY temp_bigint ASC';
+        $row = $connection->getPArray($query, ['char10-2', 'char202']);
+        $this->assertCount(0, $row, 'testDataBase getArray 2 params count');
 
-        $strQuery = 'SELECT * FROM ' . self::TEST_TABLE_NAME . '  WHERE temp_char10 = ? AND temp_char20 = ? ORDER BY temp_bigint ASC';
-        $arrRow = $connection->getPArray($strQuery, ['2', null]);
-        $this->assertCount(0, $arrRow, 'testDataBase getArray 2 params count');
+        $query = 'SELECT * FROM ' . self::TEST_TABLE_NAME . '  WHERE temp_char10 = ? AND temp_char20 = ? ORDER BY temp_bigint ASC';
+        $row = $connection->getPArray($query, ['2', null]);
+        $this->assertCount(0, $row, 'testDataBase getArray 2 params count');
 
-        $strQuery = 'DROP TABLE ' . self::TEST_TABLE_NAME;
-        $this->assertTrue($connection->_pQuery($strQuery), 'testDataBase dropTable');
+        $query = 'DROP TABLE ' . self::TEST_TABLE_NAME;
+        $this->assertTrue($connection->_pQuery($query), 'testDataBase dropTable');
     }
 
     /**
@@ -98,12 +98,13 @@ class ConnectionPreparedTest extends ConnectionTestCase
     {
         $connection = $this->getConnection();
 
-        $arrFields = [];
-        $arrFields['temp_id'] = [DataType::CHAR20, false];
-        $arrFields['temp_long'] = [DataType::BIGINT, true];
-        $arrFields['temp_double'] = [DataType::FLOAT, true];
+        $columns = [
+            'temp_id' => [DataType::CHAR20, false],
+            'temp_long' => [DataType::BIGINT, true],
+            'temp_double' => [DataType::FLOAT, true],
+        ];
 
-        $this->assertTrue($connection->createTable('agp_temp_autotest_float', $arrFields, ['temp_id']), 'testDataBase createTable');
+        $this->assertTrue($connection->createTable('agp_temp_autotest_float', $columns, ['temp_id']), 'testDataBase createTable');
 
         $connection->_pQuery('DELETE FROM ' . self::TEST_TABLE_NAME . ' WHERE 1 = 1');
 
@@ -113,15 +114,15 @@ class ConnectionPreparedTest extends ConnectionTestCase
             [['id1', 123456, 1.7], ['id2', '123456', '1.7']]
         );
 
-        $arrRow = $connection->getPRow('SELECT * FROM ' . self::TEST_TABLE_NAME . ' WHERE temp_id = ?', ['id1']);
+        $row = $connection->getPRow('SELECT * FROM ' . self::TEST_TABLE_NAME . ' WHERE temp_id = ?', ['id1']);
 
-        $this->assertEquals(123456, $arrRow['temp_bigint']);
-        $this->assertEquals(1.7, round((float) $arrRow['temp_float'], 1));
+        $this->assertEquals(123456, $row['temp_bigint']);
+        $this->assertEquals(1.7, round((float) $row['temp_float'], 1));
 
-        $arrRow = $connection->getPRow('SELECT * FROM ' . self::TEST_TABLE_NAME . ' WHERE temp_id = ?', ['id2']);
+        $row = $connection->getPRow('SELECT * FROM ' . self::TEST_TABLE_NAME . ' WHERE temp_id = ?', ['id2']);
 
-        $this->assertEquals(123456, $arrRow['temp_bigint']);
-        $this->assertEquals(1.7, round((float) $arrRow['temp_float'], 1));
+        $this->assertEquals(123456, $row['temp_bigint']);
+        $this->assertEquals(1.7, round((float) $row['temp_float'], 1));
     }
 }
 

--- a/tests/ConnectionRoundTest.php
+++ b/tests/ConnectionRoundTest.php
@@ -13,9 +13,16 @@ declare(strict_types=1);
 
 namespace Artemeon\Database\Tests;
 
+use Artemeon\Database\Exception\ConnectionException;
+use Artemeon\Database\Exception\QueryException;
+
 class ConnectionRoundTest extends ConnectionTestCase
 {
-    public function testRound()
+    /**
+     * @throws ConnectionException
+     * @throws QueryException
+     */
+    public function testRound(): void
     {
         $query = 'SELECT ROUND(1.33333333333333, 8) AS val FROM ' . self::TEST_TABLE_NAME;
         $row = $this->getConnection()->getPRow($query);
@@ -24,7 +31,11 @@ class ConnectionRoundTest extends ConnectionTestCase
         $this->assertEqualsWithDelta(1 + round(1 / 3, 8), (float) $row['val'], 0.0001);
     }
 
-    public function testRoundUp()
+    /**
+     * @throws ConnectionException
+     * @throws QueryException
+     */
+    public function testRoundUp(): void
     {
         $query = 'SELECT ROUND(1.16666666666666, 8) AS val FROM ' . self::TEST_TABLE_NAME;
         $row = $this->getConnection()->getPRow($query);

--- a/tests/ConnectionStringLengthTest.php
+++ b/tests/ConnectionStringLengthTest.php
@@ -13,9 +13,16 @@ declare(strict_types=1);
 
 namespace Artemeon\Database\Tests;
 
+use Artemeon\Database\Exception\ConnectionException;
+use Artemeon\Database\Exception\QueryException;
+
 class ConnectionStringLengthTest extends ConnectionTestCase
 {
-    public function testStringLength()
+    /**
+     * @throws QueryException
+     * @throws ConnectionException
+     */
+    public function testStringLength(): void
     {
         $query = 'SELECT ' . $this->getConnection()->getStringLengthExpression('temp_char10') . ' AS val FROM ' . self::TEST_TABLE_NAME
             . ' WHERE temp_char10 = ?';

--- a/tests/ConnectionTableInformationTest.php
+++ b/tests/ConnectionTableInformationTest.php
@@ -34,8 +34,8 @@ class ConnectionTableInformationTest extends ConnectionTestCase
         $db = $this->getConnection();
 
         if (in_array(self::TEST_TABLE_NAME, $this->getConnection()->getTables(), true)) {
-            $strQuery = 'DROP TABLE ' . self::TEST_TABLE_NAME;
-            $this->getConnection()->_pQuery($strQuery);
+            $query = 'DROP TABLE ' . self::TEST_TABLE_NAME;
+            $this->getConnection()->_pQuery($query);
         }
 
         $colDefinitions = [

--- a/tests/ConnectionTableInformationTest.php
+++ b/tests/ConnectionTableInformationTest.php
@@ -13,58 +13,60 @@ declare(strict_types=1);
 
 namespace Artemeon\Database\Tests;
 
+use Artemeon\Database\Exception\ConnectionException;
+use Artemeon\Database\Exception\QueryException;
+use Artemeon\Database\Exception\TableNotFoundException;
 use Artemeon\Database\Schema\DataType;
 use Artemeon\Database\Schema\TableIndex;
 use Artemeon\Database\Schema\TableKey;
 
 class ConnectionTableInformationTest extends ConnectionTestCase
 {
-    const TEST_TABLE_NAME = "agp_temp_tableinfotest";
+    public const TEST_TABLE_NAME = 'agp_temp_tableinfotest';
 
-    public function testTypeConversion()
+    /**
+     * @throws TableNotFoundException
+     * @throws ConnectionException
+     * @throws QueryException
+     */
+    public function testTypeConversion(): void
     {
-        $objDB = $this->getConnection();
+        $db = $this->getConnection();
 
-        if (in_array(self::TEST_TABLE_NAME, $this->getConnection()->getTables())) {
-            $strQuery = "DROP TABLE ".self::TEST_TABLE_NAME;
-            $this->getConnection()->_pQuery($strQuery, array());
+        if (in_array(self::TEST_TABLE_NAME, $this->getConnection()->getTables(), true)) {
+            $strQuery = 'DROP TABLE ' . self::TEST_TABLE_NAME;
+            $this->getConnection()->_pQuery($strQuery);
         }
 
-        $colDefinitions = array();
-        $colDefinitions["temp_int"] = array(DataType::STR_TYPE_INT, false);
-        $colDefinitions["temp_long"] = array(DataType::STR_TYPE_LONG, true);
-        $colDefinitions["temp_double"] = array(DataType::STR_TYPE_DOUBLE, true);
-        $colDefinitions["temp_char10"] = array(DataType::STR_TYPE_CHAR10, true);
-        $colDefinitions["temp_char20"] = array(DataType::STR_TYPE_CHAR20, true);
-        $colDefinitions["temp_char100"] = array(DataType::STR_TYPE_CHAR100, true);
-        $colDefinitions["temp_char254"] = array(DataType::STR_TYPE_CHAR254, true);
-        $colDefinitions["temp_char500"] = array(DataType::STR_TYPE_CHAR500, true);
-        $colDefinitions["temp_text"] = array(DataType::STR_TYPE_TEXT, true);
-        $colDefinitions["temp_longtext"] = array(DataType::STR_TYPE_LONGTEXT, true);
+        $colDefinitions = [
+            'temp_int' => [DataType::INT, false],
+            'temp_long' => [DataType::BIGINT, true],
+            'temp_double' => [DataType::FLOAT, true],
+            'temp_char10' => [DataType::CHAR10, true],
+            'temp_char20' => [DataType::CHAR20, true],
+            'temp_char100' => [DataType::CHAR100, true],
+            'temp_char254' => [DataType::CHAR254, true],
+            'temp_char500' => [DataType::CHAR500, true],
+            'temp_text' => [DataType::TEXT, true],
+            'temp_longtext' => [DataType::LONGTEXT, true],
+        ];
 
-        $this->assertTrue($objDB->createTable(self::TEST_TABLE_NAME, $colDefinitions, ["temp_int"]));
-        $this->assertTrue($objDB->createIndex(self::TEST_TABLE_NAME, "temp_double", ["temp_double"]));
-        $this->assertTrue($objDB->createIndex(self::TEST_TABLE_NAME, "temp_char500", ["temp_char500"]));
-        $this->assertTrue($objDB->createIndex(self::TEST_TABLE_NAME, "temp_combined", ["temp_double", "temp_char500"]));
+        $this->assertTrue($db->createTable(self::TEST_TABLE_NAME, $colDefinitions, ['temp_int']));
+        $this->assertTrue($db->createIndex(self::TEST_TABLE_NAME, 'temp_double', ['temp_double']));
+        $this->assertTrue($db->createIndex(self::TEST_TABLE_NAME, 'temp_char500', ['temp_char500']));
+        $this->assertTrue($db->createIndex(self::TEST_TABLE_NAME, 'temp_combined', ['temp_double', 'temp_char500']));
 
-        //load the schema info from the db
-        $info = $objDB->getTableInformation(self::TEST_TABLE_NAME);
+        // load the schema info from the db
+        $info = $db->getTableInformation(self::TEST_TABLE_NAME);
 
-        $arrKeyNames = array_map(function (TableKey $key) {
-            return $key->getName();
-        }, $info->getPrimaryKeys());
+        $keyNames = array_map(static fn (TableKey $key) => $key->getName(), $info->getPrimaryKeys());
 
-        $this->assertTrue(in_array("temp_int", $arrKeyNames));
+        $this->assertContains('temp_int', $keyNames);
 
-        $arrIndexNames = array_map(function (TableIndex $index) {
-            return $index->getName();
-        }, $info->getIndexes());
+        $indexNames = array_map(static fn (TableIndex $index) => $index->getName(), $info->getIndexes());
 
-        $this->assertTrue(in_array("temp_double", $arrIndexNames));
-        $this->assertTrue(in_array("temp_char500", $arrIndexNames));
-        $this->assertTrue(in_array("temp_combined", $arrIndexNames));
-
-
+        $this->assertContains('temp_double', $indexNames);
+        $this->assertContains('temp_char500', $indexNames);
+        $this->assertContains('temp_combined', $indexNames);
     }
-
 }

--- a/tests/ConnectionTest.php
+++ b/tests/ConnectionTest.php
@@ -58,9 +58,9 @@ class ConnectionTest extends ConnectionTestCase
     {
         $connection = $this->getConnection();
 
-        $bitResult = $connection->createIndex(self::TEST_TABLE_NAME, 'foo_index', ['temp_char10', 'temp_char20']);
+        $result = $connection->createIndex(self::TEST_TABLE_NAME, 'foo_index', ['temp_char10', 'temp_char20']);
 
-        $this->assertTrue($bitResult);
+        $this->assertTrue($result);
     }
 
     /**
@@ -71,9 +71,9 @@ class ConnectionTest extends ConnectionTestCase
     {
         $connection = $this->getConnection();
 
-        $bitResult = $connection->createIndex(self::TEST_TABLE_NAME, 'foo_index', ['temp_char10', 'temp_char20'], true);
+        $output = $connection->createIndex(self::TEST_TABLE_NAME, 'foo_index', ['temp_char10', 'temp_char20'], true);
 
-        $this->assertTrue($bitResult);
+        $this->assertTrue($output);
     }
 
     /**
@@ -86,10 +86,10 @@ class ConnectionTest extends ConnectionTestCase
 
         $this->assertFalse($connection->hasIndex(self::TEST_TABLE_NAME, 'foo_index'));
 
-        $bitResult = $connection->createIndex(self::TEST_TABLE_NAME, 'foo_index', ['temp_char10', 'temp_char20']);
+        $output = $connection->createIndex(self::TEST_TABLE_NAME, 'foo_index', ['temp_char10', 'temp_char20']);
 
         $this->assertTrue($connection->hasIndex(self::TEST_TABLE_NAME, 'foo_index'));
-        $this->assertTrue($bitResult);
+        $this->assertTrue($output);
     }
 
     /**
@@ -119,14 +119,14 @@ class ConnectionTest extends ConnectionTestCase
         $connection->insert(self::TEST_TABLE_NAME, ['temp_id' => 'id1', 'temp_float' => 16.8]);
         $connection->insert(self::TEST_TABLE_NAME, ['temp_id' => 'id2', 'temp_float' => 1000.8]);
 
-        $arrRow = $connection->getPRow('SELECT * FROM ' . self::TEST_TABLE_NAME . ' where temp_id = ?', ['id1']);
+        $row = $connection->getPRow('SELECT * FROM ' . self::TEST_TABLE_NAME . ' where temp_id = ?', ['id1']);
         // MSSQL returns 16.799999237061 instead of 16.8
-        $this->assertEquals(16.8, round((float) $arrRow['temp_float'], 1));
-        $this->assertEquals('16.8', round((float) $arrRow['temp_float'], 1));
+        $this->assertEquals(16.8, round((float) $row['temp_float'], 1));
+        $this->assertEquals('16.8', round((float) $row['temp_float'], 1));
 
-        $arrRow = $connection->getPRow('SELECT * FROM ' . self::TEST_TABLE_NAME . ' where temp_id = ?', ['id2']);
-        $this->assertEquals(1000.8, round((float) $arrRow['temp_float'], 1));
-        $this->assertEquals('1000.8', round((float) $arrRow['temp_float'], 1));
+        $row = $connection->getPRow('SELECT * FROM ' . self::TEST_TABLE_NAME . ' where temp_id = ?', ['id2']);
+        $this->assertEquals(1000.8, round((float) $row['temp_float'], 1));
+        $this->assertEquals('1000.8', round((float) $row['temp_float'], 1));
     }
 
     /**
@@ -230,37 +230,37 @@ class ConnectionTest extends ConnectionTestCase
     {
         $connection = $this->getConnection();
 
-        $strQuery = 'SELECT * FROM ' . self::TEST_TABLE_NAME . ' ORDER BY temp_bigint ASC';
-        $arrRow = $connection->getPRow($strQuery);
-        $this->assertTrue(count($arrRow) >= 9, 'testDataBase getRow count');
+        $query = 'SELECT * FROM ' . self::TEST_TABLE_NAME . ' ORDER BY temp_bigint ASC';
+        $row = $connection->getPRow($query);
+        $this->assertTrue(count($row) >= 9, 'testDataBase getRow count');
 
-        $this->assertEquals('20200508095301', $arrRow['temp_bigint'], 'testDataBase getRow content');
-        $this->assertEquals(23.45, round((float) $arrRow['temp_float'], 2), 'testDataBase getRow content');
-        $this->assertEquals('char10-1', $arrRow['temp_char10'], 'testDataBase getRow content');
-        $this->assertEquals('char20-1', $arrRow['temp_char20'], 'testDataBase getRow content');
-        $this->assertEquals('char100-1', $arrRow['temp_char100'], 'testDataBase getRow content');
-        $this->assertEquals('char254-1', $arrRow['temp_char254'], 'testDataBase getRow content');
-        $this->assertEquals('char500-1', $arrRow['temp_char500'], 'testDataBase getRow content');
-        $this->assertEquals('text-1', $arrRow['temp_text'], 'testDataBase getRow content');
+        $this->assertEquals('20200508095301', $row['temp_bigint'], 'testDataBase getRow content');
+        $this->assertEquals(23.45, round((float) $row['temp_float'], 2), 'testDataBase getRow content');
+        $this->assertEquals('char10-1', $row['temp_char10'], 'testDataBase getRow content');
+        $this->assertEquals('char20-1', $row['temp_char20'], 'testDataBase getRow content');
+        $this->assertEquals('char100-1', $row['temp_char100'], 'testDataBase getRow content');
+        $this->assertEquals('char254-1', $row['temp_char254'], 'testDataBase getRow content');
+        $this->assertEquals('char500-1', $row['temp_char500'], 'testDataBase getRow content');
+        $this->assertEquals('text-1', $row['temp_text'], 'testDataBase getRow content');
 
-        $strQuery = 'SELECT * FROM ' . self::TEST_TABLE_NAME . ' ORDER BY temp_bigint ASC';
-        $arrRow = $connection->getPArray($strQuery);
-        $this->assertCount(50, $arrRow, 'testDataBase getArray count');
+        $query = 'SELECT * FROM ' . self::TEST_TABLE_NAME . ' ORDER BY temp_bigint ASC';
+        $row = $connection->getPArray($query);
+        $this->assertCount(50, $row, 'testDataBase getArray count');
 
-        $intI = 1;
-        foreach ($arrRow as $arrSingleRow) {
-            $this->assertEquals('char10-' . $intI, $arrSingleRow['temp_char10'], 'testDataBase getArray content');
-            $intI++;
+        $i = 1;
+        foreach ($row as $singleRow) {
+            $this->assertEquals('char10-' . $i, $singleRow['temp_char10'], 'testDataBase getArray content');
+            $i++;
         }
 
-        $strQuery = 'SELECT * FROM ' . self::TEST_TABLE_NAME . ' ORDER BY temp_bigint ASC';
-        $arrRow = $connection->getPArray($strQuery, [], 0, 9);
-        $this->assertCount(10, $arrRow, 'testDataBase getArraySection count');
+        $query = 'SELECT * FROM ' . self::TEST_TABLE_NAME . ' ORDER BY temp_bigint ASC';
+        $row = $connection->getPArray($query, [], 0, 9);
+        $this->assertCount(10, $row, 'testDataBase getArraySection count');
 
-        $intI = 1;
-        foreach ($arrRow as $arrSingleRow) {
-            $this->assertEquals('char10-' . $intI, $arrSingleRow['temp_char10'], 'testDataBase getArraySection content');
-            $intI++;
+        $i = 1;
+        foreach ($row as $singleRow) {
+            $this->assertEquals('char10-' . $i, $singleRow['temp_char10'], 'testDataBase getArraySection content');
+            $i++;
         }
     }
 
@@ -272,18 +272,19 @@ class ConnectionTest extends ConnectionTestCase
     {
         $connection = $this->getConnection();
 
-        $arrFields = [];
-        $arrFields['temp_id'] = [DataType::CHAR20, false];
-        $arrFields['temp_bigint'] = [DataType::BIGINT, true];
-        $arrFields['temp_float'] = [DataType::FLOAT, true];
-        $arrFields['temp_char10'] = [DataType::CHAR10, true];
-        $arrFields['temp_char20'] = [DataType::CHAR20, true];
-        $arrFields['temp_char100'] = [DataType::CHAR100, true];
-        $arrFields['temp_char254'] = [DataType::CHAR254, true];
-        $arrFields['temp_char500'] = [DataType::CHAR500, true];
-        $arrFields['temp_text'] = [DataType::TEXT, true];
+        $columns = [
+            'temp_id' => [DataType::CHAR20, false],
+            'temp_bigint' => [DataType::BIGINT, true],
+            'temp_float' => [DataType::FLOAT, true],
+            'temp_char10' => [DataType::CHAR10, true],
+            'temp_char20' => [DataType::CHAR20, true],
+            'temp_char100' => [DataType::CHAR100, true],
+            'temp_char254' => [DataType::CHAR254, true],
+            'temp_char500' => [DataType::CHAR500, true],
+            'temp_text' => [DataType::TEXT, true],
+        ];
 
-        $this->assertTrue($connection->createTable('agp_temp_autotest', $arrFields, ['temp_id'], [['temp_id', 'temp_char10', 'temp_char100'], 'temp_char254']), 'testDataBase createTable');
+        $this->assertTrue($connection->createTable('agp_temp_autotest', $columns, ['temp_id'], [['temp_id', 'temp_char10', 'temp_char100'], 'temp_char254']), 'testDataBase createTable');
     }
 
     /**
@@ -310,18 +311,18 @@ class ConnectionTest extends ConnectionTestCase
         ]);
 
         // like must be escaped
-        $strQuery = 'SELECT * FROM ' . self::TEST_TABLE_NAME . ' WHERE temp_char20 LIKE ?';
-        $arrRow = $connection->getPRow($strQuery, [$connection->escape("Foo\\Bar%")]);
+        $query = 'SELECT * FROM ' . self::TEST_TABLE_NAME . ' WHERE temp_char20 LIKE ?';
+        $row = $connection->getPRow($query, [$connection->escape("Foo\\Bar%")]);
 
-        $this->assertNotEmpty($arrRow);
-        $this->assertEquals('Foo\\Bar\\Baz', $arrRow['temp_char20']);
+        $this->assertNotEmpty($row);
+        $this->assertEquals('Foo\\Bar\\Baz', $row['temp_char20']);
 
         // equals needs no escape
-        $strQuery = 'SELECT * FROM ' . self::TEST_TABLE_NAME . ' WHERE temp_char20 = ?';
-        $arrRow = $connection->getPRow($strQuery, ["Foo\\Bar\\Baz"]);
+        $query = 'SELECT * FROM ' . self::TEST_TABLE_NAME . ' WHERE temp_char20 = ?';
+        $row = $connection->getPRow($query, ["Foo\\Bar\\Baz"]);
 
-        $this->assertNotEmpty($arrRow);
-        $this->assertEquals('Foo\\Bar\\Baz', $arrRow['temp_char20']);
+        $this->assertNotEmpty($row);
+        $this->assertEquals('Foo\\Bar\\Baz', $row['temp_char20']);
     }
 
     /**
@@ -337,14 +338,14 @@ class ConnectionTest extends ConnectionTestCase
         $this->assertEquals(20200508095301, $result[0]['temp_bigint']);
         $result = $connection->getPArray('SELECT * FROM ' . self::TEST_TABLE_NAME . ' ORDER BY temp_bigint ASC', [], 0, 7);
         $this->assertCount(8, $result);
-        for ($intI = 0; $intI < 8; $intI++) {
-            $this->assertEquals(20200508095301 + $intI, $result[$intI]['temp_bigint']);
+        for ($i = 0; $i < 8; $i++) {
+            $this->assertEquals(20200508095301 + $i, $result[$i]['temp_bigint']);
         }
 
         $result = $connection->getPArray('SELECT * FROM ' . self::TEST_TABLE_NAME . ' ORDER BY temp_bigint ASC', [], 4, 7);
         $this->assertCount(4, $result);
-        for ($intI = 4; $intI < 8; $intI++) {
-            $this->assertEquals(20200508095301 + $intI, $result[$intI - 4]['temp_bigint']);
+        for ($i = 4; $i < 8; $i++) {
+            $this->assertEquals(20200508095301 + $i, $result[$i - 4]['temp_bigint']);
         }
     }
 
@@ -355,12 +356,12 @@ class ConnectionTest extends ConnectionTestCase
     public function testGetAffectedRows(): void
     {
         $connection = $this->getConnection();
-        $strSystemId = $this->generateSystemid();
+        $systemId = $this->generateSystemid();
 
         // insert, which affects one row
         $connection->multiInsert(self::TEST_TABLE_NAME,
             ['temp_id', 'temp_char20'],
-            [[$this->generateSystemid(), $strSystemId]],
+            [[$this->generateSystemid(), $systemId]],
         );
         $this->assertEquals(1, $connection->getAffectedRowsCount());
 
@@ -368,8 +369,8 @@ class ConnectionTest extends ConnectionTestCase
         $connection->multiInsert(self::TEST_TABLE_NAME,
             ['temp_id', 'temp_char20'],
             [
-                [$this->generateSystemid(), $strSystemId],
-                [$this->generateSystemid(), $strSystemId],
+                [$this->generateSystemid(), $systemId],
+                [$this->generateSystemid(), $systemId],
             ],
         );
         $this->assertEquals(2, $connection->getAffectedRowsCount());
@@ -377,7 +378,7 @@ class ConnectionTest extends ConnectionTestCase
         $newSystemId = $this->generateSystemid();
 
         // update, which affects multiple rows
-        $connection->_pQuery('UPDATE ' . self::TEST_TABLE_NAME . ' SET temp_char20 = ? WHERE temp_char20 = ?', [$newSystemId, $strSystemId]);
+        $connection->_pQuery('UPDATE ' . self::TEST_TABLE_NAME . ' SET temp_char20 = ? WHERE temp_char20 = ?', [$newSystemId, $systemId]);
         $this->assertEquals(3, $connection->getAffectedRowsCount());
 
         // update, which does not affect a row
@@ -525,17 +526,17 @@ class ConnectionTest extends ConnectionTestCase
         $connection = $this->getConnection();
         $generator = $connection->getGenerator('SELECT * FROM ' . self::TEST_TABLE_NAME . ' ORDER BY temp_int ASC', [], 6);
 
-        $intI = 0;
+        $i = 0;
         $j = 0;
-        foreach ($generator as $arrResult) {
-            $this->assertCount($j === 8 ? 2 : 6, $arrResult);
-            foreach ($arrResult as $arrRow) {
-                $this->assertEquals('char20-' . ($intI + 1), $arrRow['temp_char20']);
-                $intI++;
+        foreach ($generator as $result) {
+            $this->assertCount($j === 8 ? 2 : 6, $result);
+            foreach ($result as $row) {
+                $this->assertEquals('char20-' . ($i + 1), $row['temp_char20']);
+                $i++;
             }
             $j++;
         }
-        $this->assertEquals(50, $intI);
+        $this->assertEquals(50, $i);
         $this->assertEquals(9, $j);
 
         $connection->_pQuery('DROP TABLE ' . self::TEST_TABLE_NAME);
@@ -632,25 +633,25 @@ class ConnectionTest extends ConnectionTestCase
      * @throws ConnectionException
      * @throws QueryException
      */
-    public function testIntComparison($strId, $longDate, $longExpected): void
+    public function testIntComparison($id, $date, $expected): void
     {
         // note calculation does not work if we cross a year border.
-        $objLeftDate = DateTime::createFromFormat('YmdHis', '' . $longDate);
+        $objLeftDate = DateTime::createFromFormat('YmdHis', '' . $date);
         $objLeftDate->add(new DateInterval('P1M'));
         $left = $objLeftDate->format('YmdHis');
 
         $objDB = $this->getConnection();
         $objDB->insert(self::TEST_TABLE_NAME, [
-            'temp_id' => $strId,
-            'temp_bigint' => $longDate,
+            'temp_id' => $id,
+            'temp_bigint' => $date,
         ]);
 
-        $strQuery = 'SELECT ' . $left . ' - ' . $longDate . ' AS result_1, ' . $left . ' - temp_bigint AS result_2 FROM ' . self::TEST_TABLE_NAME . ' WHERE temp_id = ?';
-        $arrRow = $objDB->getPRow($strQuery, [$strId]);
+        $query = 'SELECT ' . $left . ' - ' . $date . ' AS result_1, ' . $left . ' - temp_bigint AS result_2 FROM ' . self::TEST_TABLE_NAME . ' WHERE temp_id = ?';
+        $row = $objDB->getPRow($query, [$id]);
 
-        $this->assertEquals($longExpected, $left - $longDate);
-        $this->assertEquals($longExpected, $arrRow['result_1']);
-        $this->assertEquals($longExpected, $arrRow['result_2']);
+        $this->assertEquals($expected, $left - $date);
+        $this->assertEquals($expected, $row['result_1']);
+        $this->assertEquals($expected, $row['result_2']);
     }
 
     public function intComparisonDataProvider(): array

--- a/tests/ConnectionTestCase.php
+++ b/tests/ConnectionTestCase.php
@@ -16,12 +16,11 @@ namespace Artemeon\Database\Tests;
 use Artemeon\Database\Connection;
 use Artemeon\Database\ConnectionParameters;
 use Artemeon\Database\DriverFactory;
+use Artemeon\Database\Exception\ConnectionException;
+use Artemeon\Database\Exception\QueryException;
 use Artemeon\Database\Schema\DataType;
 use PHPUnit\Framework\TestCase;
 
-/**
- * @since 7.3
- */
 abstract class ConnectionTestCase extends TestCase
 {
     private static $connection;
@@ -60,14 +59,18 @@ abstract class ConnectionTestCase extends TestCase
         return self::$connection = new Connection($params, $factory);
     }
 
-    protected function flushDBCache()
+    protected function flushDBCache(): void
     {
         $this->getConnection()->flushPreparedStatementsCache();
         $this->getConnection()->flushQueryCache();
         $this->getConnection()->flushTablesCache();
     }
 
-    private function setupFixture()
+    /**
+     * @throws ConnectionException
+     * @throws QueryException
+     */
+    private function setupFixture(): void
     {
         $this->getConnection()->dropTable(self::TEST_TABLE_NAME);
         $this->getConnection()->createTable(self::TEST_TABLE_NAME, $this->getTestTableColumns(), ['temp_id']);
@@ -80,18 +83,18 @@ abstract class ConnectionTestCase extends TestCase
 
     protected function getTestTableColumns(): array
     {
-        $columns = array();
-        $columns["temp_id"] = array(DataType::STR_TYPE_CHAR20, false);
-        $columns["temp_int"] = array(DataType::STR_TYPE_INT, true);
-        $columns["temp_bigint"] = array(DataType::STR_TYPE_BIGINT, true);
-        $columns["temp_float"] = array(DataType::STR_TYPE_FLOAT, true);
-        $columns["temp_char10"] = array(DataType::STR_TYPE_CHAR10, true);
-        $columns["temp_char20"] = array(DataType::STR_TYPE_CHAR20, true);
-        $columns["temp_char100"] = array(DataType::STR_TYPE_CHAR100, true);
-        $columns["temp_char254"] = array(DataType::STR_TYPE_CHAR254, true);
-        $columns["temp_char500"] = array(DataType::STR_TYPE_CHAR500, true);
-        $columns["temp_text"] = array(DataType::STR_TYPE_TEXT, true);
-        $columns["temp_longtext"] = array(DataType::STR_TYPE_LONGTEXT, true);
+        $columns = [];
+        $columns['temp_id'] = [DataType::CHAR20, false];
+        $columns['temp_int'] = [DataType::INT, true];
+        $columns['temp_bigint'] = [DataType::BIGINT, true];
+        $columns['temp_float'] = [DataType::FLOAT, true];
+        $columns['temp_char10'] = [DataType::CHAR10, true];
+        $columns['temp_char20'] = [DataType::CHAR20, true];
+        $columns['temp_char100'] = [DataType::CHAR100, true];
+        $columns['temp_char254'] = [DataType::CHAR254, true];
+        $columns['temp_char500'] = [DataType::CHAR500, true];
+        $columns['temp_text'] = [DataType::TEXT, true];
+        $columns['temp_longtext'] = [DataType::LONGTEXT, true];
 
         return $columns;
     }

--- a/tests/ConnectionTxTest.php
+++ b/tests/ConnectionTxTest.php
@@ -22,62 +22,63 @@ class ConnectionTxTest extends ConnectionTestCase
     {
         $connection = $this->getConnection();
 
-        $arrFields = [];
-        $arrFields['temp_id'] = [DataType::CHAR20, false];
-        $arrFields['temp_long'] = [DataType::BIGINT, true];
-        $arrFields['temp_double'] = [DataType::FLOAT, true];
-        $arrFields['temp_char10'] = [DataType::CHAR10, true];
-        $arrFields['temp_char20'] = [DataType::CHAR20, true];
-        $arrFields['temp_char100'] = [DataType::CHAR100, true];
-        $arrFields['temp_char254'] = [DataType::CHAR254, true];
-        $arrFields['temp_char500'] = [DataType::CHAR500, true];
-        $arrFields['temp_text'] = [DataType::TEXT, true];
+        $columns = [
+            'temp_id' => [DataType::CHAR20, false],
+            'temp_long' => [DataType::BIGINT, true],
+            'temp_double' => [DataType::FLOAT, true],
+            'temp_char10' => [DataType::CHAR10, true],
+            'temp_char20' => [DataType::CHAR20, true],
+            'temp_char100' => [DataType::CHAR100, true],
+            'temp_char254' => [DataType::CHAR254, true],
+            'temp_char500' => [DataType::CHAR500, true],
+            'temp_text' => [DataType::TEXT, true],
+        ];
 
-        $this->assertTrue($connection->createTable('agp_temp_autotest_tx', $arrFields, ['temp_id']), 'testTx createTable');
+        $this->assertTrue($connection->createTable('agp_temp_autotest_tx', $columns, ['temp_id']), 'testTx createTable');
 
         $connection->_pQuery('DELETE FROM agp_temp_autotest_tx WHERE 1=1');
 
-        $intI = 1;
-        $strQuery = "INSERT INTO agp_temp_autotest_tx
+        $i = 1;
+        $query = "INSERT INTO agp_temp_autotest_tx
             (temp_id, temp_long, temp_double, temp_char10, temp_char20, temp_char100, temp_char254, temp_char500, temp_text)
             VALUES
-            ('" . $this->generateSystemid() . "', 123456" . $intI . ', 23.45' . $intI . ", '" . $intI . "', 'char20" . $intI . "', 'char100" . $intI . "', 'char254" . $intI . "', 'char500" . $intI . "', 'text" . $intI . "')";
+            ('" . $this->generateSystemid() . "', 123456" . $i . ', 23.45' . $i . ", '" . $i . "', 'char20" . $i . "', 'char100" . $i . "', 'char254" . $i . "', 'char500" . $i . "', 'text" . $i . "')";
 
-        $this->assertTrue($connection->_pQuery($strQuery), 'testTx insert');
+        $this->assertTrue($connection->_pQuery($query), 'testTx insert');
 
-        $strQuery = 'SELECT * FROM agp_temp_autotest_tx ORDER BY temp_long ASC';
-        $arrRow = $connection->getPArray($strQuery);
-        $this->assertEquals(1, count($arrRow), 'testDataBase getRow count');
-        $this->assertEquals('1', $arrRow[0]['temp_char10'], 'testTx getRow content');
+        $query = 'SELECT * FROM agp_temp_autotest_tx ORDER BY temp_long ASC';
+        $rows = $connection->getPArray($query);
+        $this->assertEquals(1, count($rows), 'testDataBase getRow count');
+        $this->assertEquals('1', $rows[0]['temp_char10'], 'testTx getRow content');
 
         $connection->flushQueryCache();
         $connection->beginTransaction();
 
-        $intI = 2;
-        $strQuery = "INSERT INTO agp_temp_autotest_tx
+        $i = 2;
+        $query = "INSERT INTO agp_temp_autotest_tx
             (temp_id, temp_long, temp_double, temp_char10, temp_char20, temp_char100, temp_char254, temp_char500, temp_text)
             VALUES
-            ('" . $this->generateSystemid() . "', 123456" . $intI . ', 23.45' . $intI . ", '" . $intI . "', 'char20" . $intI . "', 'char100" . $intI . "', 'char254" . $intI . "', 'char500" . $intI . "', 'text" . $intI . "')";
+            ('" . $this->generateSystemid() . "', 123456" . $i . ', 23.45' . $i . ", '" . $i . "', 'char20" . $i . "', 'char100" . $i . "', 'char254" . $i . "', 'char500" . $i . "', 'text" . $i . "')";
 
-        $this->assertTrue($connection->_pQuery($strQuery), 'testTx insert');
+        $this->assertTrue($connection->_pQuery($query), 'testTx insert');
 
         $connection->rollbackTransaction();
-        $arrCount = $connection->getPRow('SELECT COUNT(*) AS cnt FROM agp_temp_autotest_tx');
-        $this->assertEquals(1, $arrCount['cnt'], 'testTx rollback');
+        $count = $connection->getPRow('SELECT COUNT(*) AS cnt FROM agp_temp_autotest_tx');
+        $this->assertEquals(1, $count['cnt'], 'testTx rollback');
 
         $connection->flushQueryCache();
 
         $connection->beginTransaction();
-        $this->assertTrue($connection->_pQuery($strQuery), 'testTx insert');
+        $this->assertTrue($connection->_pQuery($query), 'testTx insert');
         $connection->commitTransaction();
 
-        $arrCount = $connection->getPRow('SELECT COUNT(*) AS cnt FROM agp_temp_autotest_tx');
-        $this->assertEquals(2, $arrCount['cnt'], 'testTx rollback');
+        $count = $connection->getPRow('SELECT COUNT(*) AS cnt FROM agp_temp_autotest_tx');
+        $this->assertEquals(2, $count['cnt'], 'testTx rollback');
 
         $connection->flushQueryCache();
 
-        $strQuery = 'DROP TABLE agp_temp_autotest_tx';
-        $this->assertTrue($connection->_pQuery($strQuery), 'testTx dropTable');
+        $query = 'DROP TABLE agp_temp_autotest_tx';
+        $this->assertTrue($connection->_pQuery($query), 'testTx dropTable');
     }
 
     public function testRollbackOnCommit()

--- a/tests/ConnectionTxTest.php
+++ b/tests/ConnectionTxTest.php
@@ -14,69 +14,70 @@ declare(strict_types=1);
 namespace Artemeon\Database\Tests;
 
 use Artemeon\Database\Exception\CommitException;
+use Artemeon\Database\Schema\DataType;
 
 class ConnectionTxTest extends ConnectionTestCase
 {
-    public function test()
+    public function test(): void
     {
         $connection = $this->getConnection();
 
-        $arrFields = array();
-        $arrFields["temp_id"] = array("char20", false);
-        $arrFields["temp_long"] = array("long", true);
-        $arrFields["temp_double"] = array("double", true);
-        $arrFields["temp_char10"] = array("char10", true);
-        $arrFields["temp_char20"] = array("char20", true);
-        $arrFields["temp_char100"] = array("char100", true);
-        $arrFields["temp_char254"] = array("char254", true);
-        $arrFields["temp_char500"] = array("char500", true);
-        $arrFields["temp_text"] = array("text", true);
+        $arrFields = [];
+        $arrFields['temp_id'] = [DataType::CHAR20, false];
+        $arrFields['temp_long'] = [DataType::BIGINT, true];
+        $arrFields['temp_double'] = [DataType::FLOAT, true];
+        $arrFields['temp_char10'] = [DataType::CHAR10, true];
+        $arrFields['temp_char20'] = [DataType::CHAR20, true];
+        $arrFields['temp_char100'] = [DataType::CHAR100, true];
+        $arrFields['temp_char254'] = [DataType::CHAR254, true];
+        $arrFields['temp_char500'] = [DataType::CHAR500, true];
+        $arrFields['temp_text'] = [DataType::TEXT, true];
 
-        $this->assertTrue($connection->createTable("agp_temp_autotest_tx", $arrFields, array("temp_id")), "testTx createTable");
+        $this->assertTrue($connection->createTable('agp_temp_autotest_tx', $arrFields, ['temp_id']), 'testTx createTable');
 
-        $connection->_pQuery('DELETE FROM agp_temp_autotest_tx WHERE 1=1', []);
+        $connection->_pQuery('DELETE FROM agp_temp_autotest_tx WHERE 1=1');
 
         $intI = 1;
         $strQuery = "INSERT INTO agp_temp_autotest_tx
             (temp_id, temp_long, temp_double, temp_char10, temp_char20, temp_char100, temp_char254, temp_char500, temp_text)
             VALUES
-            ('" . $this->generateSystemid() . "', 123456" . $intI . ", 23.45" . $intI . ", '" . $intI . "', 'char20" . $intI . "', 'char100" . $intI . "', 'char254" . $intI . "', 'char500" . $intI . "', 'text" . $intI . "')";
+            ('" . $this->generateSystemid() . "', 123456" . $intI . ', 23.45' . $intI . ", '" . $intI . "', 'char20" . $intI . "', 'char100" . $intI . "', 'char254" . $intI . "', 'char500" . $intI . "', 'text" . $intI . "')";
 
-        $this->assertTrue($connection->_pQuery($strQuery, []), "testTx insert");
+        $this->assertTrue($connection->_pQuery($strQuery), 'testTx insert');
 
-        $strQuery = "SELECT * FROM agp_temp_autotest_tx ORDER BY temp_long ASC";
-        $arrRow = $connection->getPArray($strQuery, array());
-        $this->assertEquals(1, count($arrRow), "testDataBase getRow count");
-        $this->assertEquals("1", $arrRow[0]["temp_char10"], "testTx getRow content");
+        $strQuery = 'SELECT * FROM agp_temp_autotest_tx ORDER BY temp_long ASC';
+        $arrRow = $connection->getPArray($strQuery);
+        $this->assertEquals(1, count($arrRow), 'testDataBase getRow count');
+        $this->assertEquals('1', $arrRow[0]['temp_char10'], 'testTx getRow content');
 
         $connection->flushQueryCache();
-        $connection->transactionBegin();
+        $connection->beginTransaction();
 
         $intI = 2;
         $strQuery = "INSERT INTO agp_temp_autotest_tx
             (temp_id, temp_long, temp_double, temp_char10, temp_char20, temp_char100, temp_char254, temp_char500, temp_text)
             VALUES
-            ('" . $this->generateSystemid() . "', 123456" . $intI . ", 23.45" . $intI . ", '" . $intI . "', 'char20" . $intI . "', 'char100" . $intI . "', 'char254" . $intI . "', 'char500" . $intI . "', 'text" . $intI . "')";
+            ('" . $this->generateSystemid() . "', 123456" . $intI . ', 23.45' . $intI . ", '" . $intI . "', 'char20" . $intI . "', 'char100" . $intI . "', 'char254" . $intI . "', 'char500" . $intI . "', 'text" . $intI . "')";
 
-        $this->assertTrue($connection->_pQuery($strQuery, []), "testTx insert");
+        $this->assertTrue($connection->_pQuery($strQuery), 'testTx insert');
 
-        $connection->transactionRollback();
-        $arrCount = $connection->getPRow("SELECT COUNT(*) AS cnt FROM agp_temp_autotest_tx", array());
-        $this->assertEquals(1, $arrCount["cnt"], "testTx rollback");
-
-        $connection->flushQueryCache();
-
-        $connection->transactionBegin();
-        $this->assertTrue($connection->_pQuery($strQuery, []), "testTx insert");
-        $connection->transactionCommit();
-
-        $arrCount = $connection->getPRow("SELECT COUNT(*) AS cnt FROM agp_temp_autotest_tx", array());
-        $this->assertEquals(2, $arrCount["cnt"], "testTx rollback");
+        $connection->rollbackTransaction();
+        $arrCount = $connection->getPRow('SELECT COUNT(*) AS cnt FROM agp_temp_autotest_tx');
+        $this->assertEquals(1, $arrCount['cnt'], 'testTx rollback');
 
         $connection->flushQueryCache();
 
-        $strQuery = "DROP TABLE agp_temp_autotest_tx";
-        $this->assertTrue($connection->_pQuery($strQuery, []), "testTx dropTable");
+        $connection->beginTransaction();
+        $this->assertTrue($connection->_pQuery($strQuery), 'testTx insert');
+        $connection->commitTransaction();
+
+        $arrCount = $connection->getPRow('SELECT COUNT(*) AS cnt FROM agp_temp_autotest_tx');
+        $this->assertEquals(2, $arrCount['cnt'], 'testTx rollback');
+
+        $connection->flushQueryCache();
+
+        $strQuery = 'DROP TABLE agp_temp_autotest_tx';
+        $this->assertTrue($connection->_pQuery($strQuery), 'testTx dropTable');
     }
 
     public function testRollbackOnCommit()
@@ -84,10 +85,10 @@ class ConnectionTxTest extends ConnectionTestCase
         $this->expectException(CommitException::class);
 
         $connection = $this->getConnection();
-        $connection->transactionBegin();
-        $connection->transactionBegin();
-        $connection->transactionRollback();
-        $connection->transactionCommit();
+        $connection->beginTransaction();
+        $connection->beginTransaction();
+        $connection->rollbackTransaction();
+        $connection->commitTransaction();
     }
 }
 

--- a/tests/ConnectionUpsertTest.php
+++ b/tests/ConnectionUpsertTest.php
@@ -24,58 +24,59 @@ class ConnectionUpsertTest extends ConnectionTestCase
         $objDB = $this->getConnection();
 
         if (in_array('agp_temp_upserttest', $this->getConnection()->getTables())) {
-            $strQuery = 'DROP TABLE agp_temp_upserttest';
-            $this->getConnection()->_pQuery($strQuery);
+            $query = 'DROP TABLE agp_temp_upserttest';
+            $this->getConnection()->_pQuery($query);
         }
 
-        $arrFields = [];
-        $arrFields['temp_id'] = [DataType::CHAR20, false];
-        $arrFields['temp_int'] = [DataType::INT, true];
-        $arrFields['temp_text'] = [DataType::TEXT, true];
+        $columns = [
+            'temp_id' => [DataType::CHAR20, false],
+            'temp_int' => [DataType::INT, true],
+            'temp_text' => [DataType::TEXT, true],
+        ];
 
-        $this->assertTrue($objDB->createTable('agp_temp_upserttest', $arrFields, ['temp_id']));
+        $this->assertTrue($objDB->createTable('agp_temp_upserttest', $columns, ['temp_id']));
 
         $this->assertEquals(count($objDB->getPArray('SELECT * FROM agp_temp_upserttest')), 0);
 
-        $strId1 = $this->generateSystemid();
-        $objDB->insertOrUpdate('agp_temp_upserttest', ['temp_id', 'temp_int', 'temp_text'], [$strId1, 1, 'row 1'], ['temp_id']);
+        $id1 = $this->generateSystemid();
+        $objDB->insertOrUpdate('agp_temp_upserttest', ['temp_id', 'temp_int', 'temp_text'], [$id1, 1, 'row 1'], ['temp_id']);
 
         $this->assertEquals(count($objDB->getPArray('SELECT * FROM agp_temp_upserttest', [], null, null, false)), 1);
-        $arrRow = $objDB->getPRow('SELECT * FROM agp_temp_upserttest WHERE temp_id = ?', [$strId1]);
-        $this->assertEquals($arrRow['temp_int'], 1); $this->assertEquals($arrRow['temp_text'], 'row 1');
+        $row = $objDB->getPRow('SELECT * FROM agp_temp_upserttest WHERE temp_id = ?', [$id1]);
+        $this->assertEquals($row['temp_int'], 1); $this->assertEquals($row['temp_text'], 'row 1');
 
         $objDB->flushQueryCache();
 
         // first replace
-        $objDB->insertOrUpdate('agp_temp_upserttest', ['temp_id', 'temp_int', 'temp_text'], [$strId1, 2, 'row 2'], ['temp_id']);
+        $objDB->insertOrUpdate('agp_temp_upserttest', ['temp_id', 'temp_int', 'temp_text'], [$id1, 2, 'row 2'], ['temp_id']);
         $this->assertEquals(count($objDB->getPArray('SELECT * FROM agp_temp_upserttest', [], null, null, false)), 1);
-        $arrRow = $objDB->getPRow('SELECT * FROM agp_temp_upserttest WHERE temp_id = ?', [$strId1]);
-        $this->assertEquals($arrRow['temp_int'], 2); $this->assertEquals($arrRow['temp_text'], 'row 2');
+        $row = $objDB->getPRow('SELECT * FROM agp_temp_upserttest WHERE temp_id = ?', [$id1]);
+        $this->assertEquals($row['temp_int'], 2); $this->assertEquals($row['temp_text'], 'row 2');
 
-        $strId2 = $this->generateSystemid();
-        $objDB->insertOrUpdate('agp_temp_upserttest', ['temp_id', 'temp_int', 'temp_text'], [$strId2, 3, 'row 3'], ['temp_id']);
+        $id2 = $this->generateSystemid();
+        $objDB->insertOrUpdate('agp_temp_upserttest', ['temp_id', 'temp_int', 'temp_text'], [$id2, 3, 'row 3'], ['temp_id']);
 
-        $strId3 = $this->generateSystemid();
-        $objDB->insertOrUpdate('agp_temp_upserttest', ['temp_id', 'temp_int', 'temp_text'], [$strId3, 4, 'row 4'], ['temp_id']);
+        $id3 = $this->generateSystemid();
+        $objDB->insertOrUpdate('agp_temp_upserttest', ['temp_id', 'temp_int', 'temp_text'], [$id3, 4, 'row 4'], ['temp_id']);
 
-
-        $this->assertEquals(count($objDB->getPArray('SELECT * FROM agp_temp_upserttest', [], null, null, false)), 3);
-
-        $objDB->insertOrUpdate('agp_temp_upserttest', ['temp_id', 'temp_int', 'temp_text'], [$strId3, 5, 'row 5'], ['temp_id']);
 
         $this->assertEquals(count($objDB->getPArray('SELECT * FROM agp_temp_upserttest', [], null, null, false)), 3);
 
-        $arrRow = $objDB->getPRow('SELECT * FROM agp_temp_upserttest WHERE temp_id = ?', [$strId1]);
-        $this->assertEquals($arrRow['temp_int'], 2); $this->assertEquals($arrRow['temp_text'], 'row 2');
+        $objDB->insertOrUpdate('agp_temp_upserttest', ['temp_id', 'temp_int', 'temp_text'], [$id3, 5, 'row 5'], ['temp_id']);
 
-        $arrRow = $objDB->getPRow('SELECT * FROM agp_temp_upserttest WHERE temp_id = ?', [$strId2]);
-        $this->assertEquals($arrRow['temp_int'], 3); $this->assertEquals($arrRow['temp_text'], 'row 3');
+        $this->assertEquals(count($objDB->getPArray('SELECT * FROM agp_temp_upserttest', [], null, null, false)), 3);
 
-        $arrRow = $objDB->getPRow('SELECT * FROM agp_temp_upserttest WHERE temp_id = ?', [$strId3]);
-        $this->assertEquals($arrRow['temp_int'], 5); $this->assertEquals($arrRow['temp_text'], 'row 5');
+        $row = $objDB->getPRow('SELECT * FROM agp_temp_upserttest WHERE temp_id = ?', [$id1]);
+        $this->assertEquals($row['temp_int'], 2); $this->assertEquals($row['temp_text'], 'row 2');
 
-        $strQuery = 'DROP TABLE agp_temp_upserttest';
-        $this->assertTrue($objDB->_pQuery($strQuery));
+        $row = $objDB->getPRow('SELECT * FROM agp_temp_upserttest WHERE temp_id = ?', [$id2]);
+        $this->assertEquals($row['temp_int'], 3); $this->assertEquals($row['temp_text'], 'row 3');
+
+        $row = $objDB->getPRow('SELECT * FROM agp_temp_upserttest WHERE temp_id = ?', [$id3]);
+        $this->assertEquals($row['temp_int'], 5); $this->assertEquals($row['temp_text'], 'row 5');
+
+        $query = 'DROP TABLE agp_temp_upserttest';
+        $this->assertTrue($objDB->_pQuery($query));
     }
 
     /**
@@ -87,61 +88,62 @@ class ConnectionUpsertTest extends ConnectionTestCase
         $objDB = $this->getConnection();
 
         if (in_array('agp_temp_upserttest2', $this->getConnection()->getTables(), true)) {
-            $strQuery = 'DROP TABLE agp_temp_upserttest2';
-            $this->getConnection()->_pQuery($strQuery);
+            $query = 'DROP TABLE agp_temp_upserttest2';
+            $this->getConnection()->_pQuery($query);
         }
 
-        $arrFields = [];
-        $arrFields['temp_id'] = [DataType::CHAR20, false];
-        $arrFields['temp_id2'] = [DataType::INT, false];
-        $arrFields['temp_int'] = [DataType::INT, true];
-        $arrFields['temp_text'] = [DataType::TEXT, true];
+        $columns = [
+            'temp_id' => [DataType::CHAR20, false],
+            'temp_id2' => [DataType::INT, false],
+            'temp_int' => [DataType::INT, true],
+            'temp_text' => [DataType::TEXT, true],
+        ];
 
-        $this->assertTrue($objDB->createTable('agp_temp_upserttest2', $arrFields, ['temp_id', 'temp_id2']));
+        $this->assertTrue($objDB->createTable('agp_temp_upserttest2', $columns, ['temp_id', 'temp_id2']));
 
         $this->assertCount(0, $objDB->getPArray('SELECT * FROM agp_temp_upserttest2'));
 
-        $strId = $this->generateSystemid();
+        $id = $this->generateSystemid();
 
-        $objDB->insertOrUpdate('agp_temp_upserttest2', ['temp_id', 'temp_id2', 'temp_int', 'temp_text'], [$strId, 1, 1, 'row 1'], ['temp_id', 'temp_id2']);
+        $objDB->insertOrUpdate('agp_temp_upserttest2', ['temp_id', 'temp_id2', 'temp_int', 'temp_text'], [$id, 1, 1, 'row 1'], ['temp_id', 'temp_id2']);
 
         $this->assertCount(1, $objDB->getPArray('SELECT * FROM agp_temp_upserttest2', [], null, null, false));
-        $arrRow = $objDB->getPRow('SELECT * FROM agp_temp_upserttest2 WHERE temp_id = ? AND temp_id2 = ?', [$strId, 1]);
-        $this->assertEquals(1, $arrRow['temp_int']);
-        $this->assertEquals('row 1', $arrRow['temp_text']);
+        $row = $objDB->getPRow('SELECT * FROM agp_temp_upserttest2 WHERE temp_id = ? AND temp_id2 = ?', [$id, 1]);
+        $this->assertEquals(1, $row['temp_int']);
+        $this->assertEquals('row 1', $row['temp_text']);
 
         $objDB->flushQueryCache();
 
         // first replace
-        $objDB->insertOrUpdate('agp_temp_upserttest2', ['temp_id', 'temp_id2', 'temp_int', 'temp_text'], [$strId, 1, 2, 'row 2'], ['temp_id', 'temp_id2']);
+        $objDB->insertOrUpdate('agp_temp_upserttest2', ['temp_id', 'temp_id2', 'temp_int', 'temp_text'], [$id, 1, 2, 'row 2'], ['temp_id', 'temp_id2']);
         $this->assertCount(1, $objDB->getPArray('SELECT * FROM agp_temp_upserttest2', [], null, null, false));
-        $arrRow = $objDB->getPRow('SELECT * FROM agp_temp_upserttest2 WHERE temp_id = ? AND temp_id2 = ?', [$strId, 1]);
-        $this->assertEquals(2, $arrRow['temp_int']);
-        $this->assertEquals('row 2', $arrRow['temp_text']);
+        $row = $objDB->getPRow('SELECT * FROM agp_temp_upserttest2 WHERE temp_id = ? AND temp_id2 = ?', [$id, 1]);
+        $this->assertEquals(2, $row['temp_int']);
+        $this->assertEquals('row 2', $row['temp_text']);
 
-        $objDB->insertOrUpdate('agp_temp_upserttest2', ['temp_id', 'temp_id2', 'temp_int', 'temp_text'], [$strId, 2, 3, 'row 3'], ['temp_id', 'temp_id2']);
-        $objDB->insertOrUpdate('agp_temp_upserttest2', ['temp_id', 'temp_id2', 'temp_int', 'temp_text'], [$strId, 3, 4, 'row 4'], ['temp_id', 'temp_id2']);
-
-        $this->assertCount(3, $objDB->getPArray('SELECT * FROM agp_temp_upserttest2', [], null, null, false));
-
-        $objDB->insertOrUpdate('agp_temp_upserttest2', ['temp_id', 'temp_id2', 'temp_int', 'temp_text'], [$strId, 3, 5, 'row 5'], ['temp_id', 'temp_id2']);
+        $objDB->insertOrUpdate('agp_temp_upserttest2', ['temp_id', 'temp_id2', 'temp_int', 'temp_text'], [$id, 2, 3, 'row 3'], ['temp_id', 'temp_id2']);
+        $objDB->insertOrUpdate('agp_temp_upserttest2', ['temp_id', 'temp_id2', 'temp_int', 'temp_text'], [$id, 3, 4, 'row 4'], ['temp_id', 'temp_id2']);
 
         $this->assertCount(3, $objDB->getPArray('SELECT * FROM agp_temp_upserttest2', [], null, null, false));
 
-        $arrRow = $objDB->getPRow('SELECT * FROM agp_temp_upserttest2 WHERE temp_id = ? AND temp_id2 = ?', [$strId, 1]);
-        $this->assertEquals(2, $arrRow['temp_int']);
-        $this->assertEquals('row 2', $arrRow['temp_text']);
+        $objDB->insertOrUpdate('agp_temp_upserttest2', ['temp_id', 'temp_id2', 'temp_int', 'temp_text'], [$id, 3, 5, 'row 5'], ['temp_id', 'temp_id2']);
 
-        $arrRow = $objDB->getPRow('SELECT * FROM agp_temp_upserttest2 WHERE temp_id = ? AND temp_id2 = ?', array($strId, 2));
-        $this->assertEquals(3, $arrRow['temp_int']);
-        $this->assertEquals('row 3', $arrRow['temp_text']);
+        $this->assertCount(3, $objDB->getPArray('SELECT * FROM agp_temp_upserttest2', [], null, null, false));
 
-        $arrRow = $objDB->getPRow('SELECT * FROM agp_temp_upserttest2 WHERE temp_id = ? AND temp_id2 = ?', array($strId, 3));
-        $this->assertEquals(5, $arrRow['temp_int']);
-        $this->assertEquals('row 5', $arrRow['temp_text']);
+        $row = $objDB->getPRow('SELECT * FROM agp_temp_upserttest2 WHERE temp_id = ? AND temp_id2 = ?', [$id, 1]);
+        $this->assertEquals(2, $row['temp_int']);
+        $this->assertEquals('row 2', $row['temp_text']);
 
-        $strQuery = 'DROP TABLE agp_temp_upserttest2';
-        $this->assertTrue($objDB->_pQuery($strQuery));
+        $row = $objDB->getPRow('SELECT * FROM agp_temp_upserttest2 WHERE temp_id = ? AND temp_id2 = ?', array($id, 2));
+        $this->assertEquals(3, $row['temp_int']);
+        $this->assertEquals('row 3', $row['temp_text']);
+
+        $row = $objDB->getPRow('SELECT * FROM agp_temp_upserttest2 WHERE temp_id = ? AND temp_id2 = ?', array($id, 3));
+        $this->assertEquals(5, $row['temp_int']);
+        $this->assertEquals('row 5', $row['temp_text']);
+
+        $query = 'DROP TABLE agp_temp_upserttest2';
+        $this->assertTrue($objDB->_pQuery($query));
     }
 
     /**
@@ -152,76 +154,76 @@ class ConnectionUpsertTest extends ConnectionTestCase
     {
         $objDB = $this->getConnection();
         if (in_array('agp_temp_upserttest3', $this->getConnection()->getTables(), true)) {
-            $strQuery = 'DROP TABLE agp_temp_upserttest3';
-            $this->getConnection()->_pQuery($strQuery);
+            $query = 'DROP TABLE agp_temp_upserttest3';
+            $this->getConnection()->_pQuery($query);
         }
 
-        $arrFields = [
+        $columns = [
             'temp_id' => [DataType::CHAR20, false],
             'temp_id2' => [DataType::INT, false],
             'temp_int' => [DataType::INT, true],
             'temp_text' => [DataType::TEXT, true],
         ];
 
-        $this->assertTrue($objDB->createTable('agp_temp_upserttest3', $arrFields, ['temp_id', 'temp_id2']));
+        $this->assertTrue($objDB->createTable('agp_temp_upserttest3', $columns, ['temp_id', 'temp_id2']));
 
-        $strId1 = $this->generateSystemid();
-        $strId2 = $this->generateSystemid();
-        $strId3 = $this->generateSystemid();
+        $id1 = $this->generateSystemid();
+        $id2 = $this->generateSystemid();
+        $id3 = $this->generateSystemid();
 
-        $arrTestData = [
-            [$strId1, 1, 1, 'text 1'],
-            [$strId1, 1, 1, 'text 1'],
-            [$strId1, 1, 1, 'text 2'],
-            [$strId1, 2, 1, 'text 1'],
-            [$strId1, 2, 3, 'text 1'],
-            [$strId2, 1, 1, 'text 1'],
-            [$strId2, 1, 1, 'text 1'],
-            [$strId2, 1, 3, 'text 1'],
-            [$strId1, 1, 3, 'text 4'],
-            [$strId1, 1, 3, 'text 5'],
-            [$strId3, 3, 3, 'text 3'],
-            [$strId3, 3, 3, 'text 4'],
-            [$strId3, 4, 3, 'text 4'],
-            [$strId3, 4, 3, 'text 4'],
-            [$strId3, 4, 5, 'text 4'],
+        $testData = [
+            [$id1, 1, 1, 'text 1'],
+            [$id1, 1, 1, 'text 1'],
+            [$id1, 1, 1, 'text 2'],
+            [$id1, 2, 1, 'text 1'],
+            [$id1, 2, 3, 'text 1'],
+            [$id2, 1, 1, 'text 1'],
+            [$id2, 1, 1, 'text 1'],
+            [$id2, 1, 3, 'text 1'],
+            [$id1, 1, 3, 'text 4'],
+            [$id1, 1, 3, 'text 5'],
+            [$id3, 3, 3, 'text 3'],
+            [$id3, 3, 3, 'text 4'],
+            [$id3, 4, 3, 'text 4'],
+            [$id3, 4, 3, 'text 4'],
+            [$id3, 4, 5, 'text 4'],
         ];
 
-        foreach($arrTestData as $arrOneRow) {
-            $this->runInsertAndUpdate($arrOneRow[0], $arrOneRow[1], $arrOneRow[2], $arrOneRow[3]);
+        foreach($testData as $row) {
+            $this->runInsertAndUpdate($row[0], $row[1], $row[2], $row[3]);
         }
 
-        foreach($arrTestData as $arrOneRow) {
-            $this->runUpsert($arrOneRow[0], $arrOneRow[1], $arrOneRow[2], $arrOneRow[3]);
+        foreach($testData as $row) {
+            $this->runUpsert($row[0], $row[1], $row[2], $row[3]);
         }
 
-        $strQuery = 'DROP TABLE agp_temp_upserttest3';
-        $this->assertTrue($objDB->_pQuery($strQuery));
+        $query = 'DROP TABLE agp_temp_upserttest3';
+        $this->assertTrue($objDB->_pQuery($query));
     }
 
     /**
      * @throws QueryException
      * @throws ConnectionException
      */
-    private function runUpsert($intId, $intId2, $intInt, $strText): void
+    private function runUpsert($id, $id2, $int, $text): void
     {
-        $this->getConnection()->insertOrUpdate('agp_temp_upserttest3', ['temp_id', 'temp_id2', 'temp_int', 'temp_text'], [$intId, $intId2, $intInt, $strText], ['temp_id', 'temp_id2']);
+        $this->getConnection()->insertOrUpdate('agp_temp_upserttest3', ['temp_id', 'temp_id2', 'temp_int', 'temp_text'], [$id, $id2, $int, $text], ['temp_id', 'temp_id2']);
     }
 
     /**
      * @throws QueryException
      * @throws ConnectionException
      */
-    private function runInsertAndUpdate($intId, $intId2, $intInt, $strText): void
+    private function runInsertAndUpdate($id, $id2, $int, $text): void
     {
         $objDb = $this->getConnection();
-        $arrRow = $objDb->getPRow('SELECT COUNT(*) AS cnt FROM agp_temp_upserttest3 WHERE temp_id = ? AND temp_id2 = ?', array($intId, $intId2), 0, false);
-        if($arrRow['cnt'] == '0') {
-            $strQuery = 'INSERT INTO agp_temp_upserttest3 (temp_id, temp_id2, temp_int, temp_text) VALUES (?, ?, ?, ?)';
-            $objDb->_pQuery($strQuery, [$intId, $intId2, $intInt, $strText]);
+        $row = $objDb->getPRow('SELECT COUNT(*) AS cnt FROM agp_temp_upserttest3 WHERE temp_id = ? AND temp_id2 = ?', array($id, $id2), 0, false);
+        if($row['cnt'] == '0') {
+            $query = 'INSERT INTO agp_temp_upserttest3 (temp_id, temp_id2, temp_int, temp_text) VALUES (?, ?, ?, ?)';
+            $objDb->_pQuery($query, [$id, $id2, $int, $text]);
         } else {
-            $strQuery = 'UPDATE agp_temp_upserttest3 SET temp_int = ?, temp_text = ? WHERE temp_id = ? AND temp_id2 = ?';
-            $objDb->_pQuery($strQuery, [$intInt, $strText, $intId, $intId2]);
+            $query = 'UPDATE agp_temp_upserttest3 SET temp_int = ?, temp_text = ? WHERE temp_id = ? AND temp_id2 = ?';
+            $objDb->_pQuery($query, [$int, $text, $id, $id2]);
         }
     }
 
@@ -231,15 +233,15 @@ class ConnectionUpsertTest extends ConnectionTestCase
      * @throws ConnectionException
      * @throws QueryException
      */
-    private function runInsertAndUpdateChangedRows($intId, $intId2, $intInt, $strText)
+    private function runInsertAndUpdateChangedRows($id, $id2, $int, $text)
     {
         $objDb = $this->getConnection();
 
-        $strQuery = 'UPDATE agp_temp_upserttest3 SET temp_int = ?, temp_text = ? WHERE temp_id = ? AND temp_id2 = ?';
-        $objDb->_pQuery($strQuery, [$intInt, $strText, $intId, $intId2]);
+        $query = 'UPDATE agp_temp_upserttest3 SET temp_int = ?, temp_text = ? WHERE temp_id = ? AND temp_id2 = ?';
+        $objDb->_pQuery($query, [$int, $text, $id, $id2]);
         if($objDb->getAffectedRowsCount() == 0) {
-            $strQuery = 'INSERT INTO agp_temp_upserttest3 (temp_id, temp_id2, temp_int, temp_text) VALUES (?, ?, ?, ?)';
-            $objDb->_pQuery($strQuery, [$intId, $intId2, $intInt, $strText]);
+            $query = 'INSERT INTO agp_temp_upserttest3 (temp_id, temp_id2, temp_int, temp_text) VALUES (?, ?, ?, ?)';
+            $objDb->_pQuery($query, [$id, $id2, $int, $text]);
         }
     }
 }

--- a/tests/ConnectionUpsertTest.php
+++ b/tests/ConnectionUpsertTest.php
@@ -13,232 +13,233 @@ declare(strict_types=1);
 
 namespace Artemeon\Database\Tests;
 
+use Artemeon\Database\Exception\ConnectionException;
+use Artemeon\Database\Exception\QueryException;
+use Artemeon\Database\Schema\DataType;
+
 class ConnectionUpsertTest extends ConnectionTestCase
 {
     public function testInsertSinglePrimaryColumn()
     {
         $objDB = $this->getConnection();
 
-        if (in_array("agp_temp_upserttest", $this->getConnection()->getTables())) {
-            $strQuery = "DROP TABLE agp_temp_upserttest";
-            $this->getConnection()->_pQuery($strQuery, array());
+        if (in_array('agp_temp_upserttest', $this->getConnection()->getTables())) {
+            $strQuery = 'DROP TABLE agp_temp_upserttest';
+            $this->getConnection()->_pQuery($strQuery);
         }
 
-        $arrFields = array();
-        $arrFields["temp_id"] = array("char20", false);
-        $arrFields["temp_int"] = array("int", true);
-        $arrFields["temp_text"] = array("text", true);
+        $arrFields = [];
+        $arrFields['temp_id'] = [DataType::CHAR20, false];
+        $arrFields['temp_int'] = [DataType::INT, true];
+        $arrFields['temp_text'] = [DataType::TEXT, true];
 
-        $this->assertTrue($objDB->createTable("agp_temp_upserttest", $arrFields, array("temp_id")));
+        $this->assertTrue($objDB->createTable('agp_temp_upserttest', $arrFields, ['temp_id']));
 
-        $this->assertEquals(count($objDB->getPArray("SELECT * FROM agp_temp_upserttest", array())), 0);
+        $this->assertEquals(count($objDB->getPArray('SELECT * FROM agp_temp_upserttest')), 0);
 
         $strId1 = $this->generateSystemid();
-        $objDB->insertOrUpdate("agp_temp_upserttest", array("temp_id", "temp_int", "temp_text"), array($strId1, 1, "row 1"), array("temp_id"));
+        $objDB->insertOrUpdate('agp_temp_upserttest', ['temp_id', 'temp_int', 'temp_text'], [$strId1, 1, 'row 1'], ['temp_id']);
 
-        $this->assertEquals(count($objDB->getPArray("SELECT * FROM agp_temp_upserttest", array(), null, null, false)), 1);
-        $arrRow = $objDB->getPRow("SELECT * FROM agp_temp_upserttest WHERE temp_id = ?", array($strId1));
-        $this->assertEquals($arrRow["temp_int"], 1); $this->assertEquals($arrRow["temp_text"], "row 1");
+        $this->assertEquals(count($objDB->getPArray('SELECT * FROM agp_temp_upserttest', [], null, null, false)), 1);
+        $arrRow = $objDB->getPRow('SELECT * FROM agp_temp_upserttest WHERE temp_id = ?', [$strId1]);
+        $this->assertEquals($arrRow['temp_int'], 1); $this->assertEquals($arrRow['temp_text'], 'row 1');
 
         $objDB->flushQueryCache();
 
-        //first replace
-        $objDB->insertOrUpdate("agp_temp_upserttest", array("temp_id", "temp_int", "temp_text"), array($strId1, 2, "row 2"), array("temp_id"));
-        $this->assertEquals(count($objDB->getPArray("SELECT * FROM agp_temp_upserttest", array(), null, null, false)), 1);
-        $arrRow = $objDB->getPRow("SELECT * FROM agp_temp_upserttest WHERE temp_id = ?", array($strId1));
-        $this->assertEquals($arrRow["temp_int"], 2); $this->assertEquals($arrRow["temp_text"], "row 2");
-
+        // first replace
+        $objDB->insertOrUpdate('agp_temp_upserttest', ['temp_id', 'temp_int', 'temp_text'], [$strId1, 2, 'row 2'], ['temp_id']);
+        $this->assertEquals(count($objDB->getPArray('SELECT * FROM agp_temp_upserttest', [], null, null, false)), 1);
+        $arrRow = $objDB->getPRow('SELECT * FROM agp_temp_upserttest WHERE temp_id = ?', [$strId1]);
+        $this->assertEquals($arrRow['temp_int'], 2); $this->assertEquals($arrRow['temp_text'], 'row 2');
 
         $strId2 = $this->generateSystemid();
-        $objDB->insertOrUpdate("agp_temp_upserttest", array("temp_id", "temp_int", "temp_text"), array($strId2, 3, "row 3"), array("temp_id"));
+        $objDB->insertOrUpdate('agp_temp_upserttest', ['temp_id', 'temp_int', 'temp_text'], [$strId2, 3, 'row 3'], ['temp_id']);
 
         $strId3 = $this->generateSystemid();
-        $objDB->insertOrUpdate("agp_temp_upserttest", array("temp_id", "temp_int", "temp_text"), array($strId3, 4, "row 4"), array("temp_id"));
+        $objDB->insertOrUpdate('agp_temp_upserttest', ['temp_id', 'temp_int', 'temp_text'], [$strId3, 4, 'row 4'], ['temp_id']);
 
 
-        $this->assertEquals(count($objDB->getPArray("SELECT * FROM agp_temp_upserttest", array(), null, null, false)), 3);
+        $this->assertEquals(count($objDB->getPArray('SELECT * FROM agp_temp_upserttest', [], null, null, false)), 3);
 
-        $objDB->insertOrUpdate("agp_temp_upserttest", array("temp_id", "temp_int", "temp_text"), array($strId3, 5, "row 5"), array("temp_id"));
+        $objDB->insertOrUpdate('agp_temp_upserttest', ['temp_id', 'temp_int', 'temp_text'], [$strId3, 5, 'row 5'], ['temp_id']);
 
-        $this->assertEquals(count($objDB->getPArray("SELECT * FROM agp_temp_upserttest", array(), null, null, false)), 3);
+        $this->assertEquals(count($objDB->getPArray('SELECT * FROM agp_temp_upserttest', [], null, null, false)), 3);
 
+        $arrRow = $objDB->getPRow('SELECT * FROM agp_temp_upserttest WHERE temp_id = ?', [$strId1]);
+        $this->assertEquals($arrRow['temp_int'], 2); $this->assertEquals($arrRow['temp_text'], 'row 2');
 
-        $arrRow = $objDB->getPRow("SELECT * FROM agp_temp_upserttest WHERE temp_id = ?", array($strId1));
-        $this->assertEquals($arrRow["temp_int"], 2); $this->assertEquals($arrRow["temp_text"], "row 2");
+        $arrRow = $objDB->getPRow('SELECT * FROM agp_temp_upserttest WHERE temp_id = ?', [$strId2]);
+        $this->assertEquals($arrRow['temp_int'], 3); $this->assertEquals($arrRow['temp_text'], 'row 3');
 
-        $arrRow = $objDB->getPRow("SELECT * FROM agp_temp_upserttest WHERE temp_id = ?", array($strId2));
-        $this->assertEquals($arrRow["temp_int"], 3); $this->assertEquals($arrRow["temp_text"], "row 3");
+        $arrRow = $objDB->getPRow('SELECT * FROM agp_temp_upserttest WHERE temp_id = ?', [$strId3]);
+        $this->assertEquals($arrRow['temp_int'], 5); $this->assertEquals($arrRow['temp_text'], 'row 5');
 
-        $arrRow = $objDB->getPRow("SELECT * FROM agp_temp_upserttest WHERE temp_id = ?", array($strId3));
-        $this->assertEquals($arrRow["temp_int"], 5); $this->assertEquals($arrRow["temp_text"], "row 5");
-
-        $strQuery = "DROP TABLE agp_temp_upserttest";
-        $this->assertTrue($objDB->_pQuery($strQuery, array()));
-
+        $strQuery = 'DROP TABLE agp_temp_upserttest';
+        $this->assertTrue($objDB->_pQuery($strQuery));
     }
 
-
-
-    public function testInsertMultiplePrimaryColumn()
+    /**
+     * @throws QueryException
+     * @throws ConnectionException
+     */
+    public function testInsertMultiplePrimaryColumn(): void
     {
         $objDB = $this->getConnection();
 
-
-        if (in_array("agp_temp_upserttest2", $this->getConnection()->getTables())) {
-            $strQuery = "DROP TABLE agp_temp_upserttest2";
-            $this->getConnection()->_pQuery($strQuery, array());
+        if (in_array('agp_temp_upserttest2', $this->getConnection()->getTables(), true)) {
+            $strQuery = 'DROP TABLE agp_temp_upserttest2';
+            $this->getConnection()->_pQuery($strQuery);
         }
 
-        $arrFields = array();
-        $arrFields["temp_id"] = array("char20", false);
-        $arrFields["temp_id2"] = array("int", false);
-        $arrFields["temp_int"] = array("int", true);
-        $arrFields["temp_text"] = array("text", true);
+        $arrFields = [];
+        $arrFields['temp_id'] = [DataType::CHAR20, false];
+        $arrFields['temp_id2'] = [DataType::INT, false];
+        $arrFields['temp_int'] = [DataType::INT, true];
+        $arrFields['temp_text'] = [DataType::TEXT, true];
 
-        $this->assertTrue($objDB->createTable("agp_temp_upserttest2", $arrFields, array("temp_id", "temp_id2")));
+        $this->assertTrue($objDB->createTable('agp_temp_upserttest2', $arrFields, ['temp_id', 'temp_id2']));
 
-
-        $this->assertEquals(count($objDB->getPArray("SELECT * FROM agp_temp_upserttest2", array())), 0);
+        $this->assertCount(0, $objDB->getPArray('SELECT * FROM agp_temp_upserttest2'));
 
         $strId = $this->generateSystemid();
 
-        $objDB->insertOrUpdate("agp_temp_upserttest2", array("temp_id", "temp_id2", "temp_int", "temp_text"), array($strId, 1, 1, "row 1"), array("temp_id", "temp_id2"));
+        $objDB->insertOrUpdate('agp_temp_upserttest2', ['temp_id', 'temp_id2', 'temp_int', 'temp_text'], [$strId, 1, 1, 'row 1'], ['temp_id', 'temp_id2']);
 
-        $this->assertEquals(count($objDB->getPArray("SELECT * FROM agp_temp_upserttest2", array(), null, null, false)), 1);
-        $arrRow = $objDB->getPRow("SELECT * FROM agp_temp_upserttest2 WHERE temp_id = ? AND temp_id2 = ?", array($strId, 1));
-        $this->assertEquals($arrRow["temp_int"], 1); $this->assertEquals($arrRow["temp_text"], "row 1");
+        $this->assertCount(1, $objDB->getPArray('SELECT * FROM agp_temp_upserttest2', [], null, null, false));
+        $arrRow = $objDB->getPRow('SELECT * FROM agp_temp_upserttest2 WHERE temp_id = ? AND temp_id2 = ?', [$strId, 1]);
+        $this->assertEquals(1, $arrRow['temp_int']);
+        $this->assertEquals('row 1', $arrRow['temp_text']);
 
         $objDB->flushQueryCache();
 
-        //first replace
-        $objDB->insertOrUpdate("agp_temp_upserttest2", array("temp_id", "temp_id2", "temp_int", "temp_text"), array($strId, 1, 2, "row 2"), array("temp_id", "temp_id2"));
-        $this->assertEquals(count($objDB->getPArray("SELECT * FROM agp_temp_upserttest2", array(), null, null, false)), 1);
-        $arrRow = $objDB->getPRow("SELECT * FROM agp_temp_upserttest2 WHERE temp_id = ? AND temp_id2 = ?", array($strId, 1));
-        $this->assertEquals($arrRow["temp_int"], 2); $this->assertEquals($arrRow["temp_text"], "row 2");
+        // first replace
+        $objDB->insertOrUpdate('agp_temp_upserttest2', ['temp_id', 'temp_id2', 'temp_int', 'temp_text'], [$strId, 1, 2, 'row 2'], ['temp_id', 'temp_id2']);
+        $this->assertCount(1, $objDB->getPArray('SELECT * FROM agp_temp_upserttest2', [], null, null, false));
+        $arrRow = $objDB->getPRow('SELECT * FROM agp_temp_upserttest2 WHERE temp_id = ? AND temp_id2 = ?', [$strId, 1]);
+        $this->assertEquals(2, $arrRow['temp_int']);
+        $this->assertEquals('row 2', $arrRow['temp_text']);
 
+        $objDB->insertOrUpdate('agp_temp_upserttest2', ['temp_id', 'temp_id2', 'temp_int', 'temp_text'], [$strId, 2, 3, 'row 3'], ['temp_id', 'temp_id2']);
+        $objDB->insertOrUpdate('agp_temp_upserttest2', ['temp_id', 'temp_id2', 'temp_int', 'temp_text'], [$strId, 3, 4, 'row 4'], ['temp_id', 'temp_id2']);
 
-        $objDB->insertOrUpdate("agp_temp_upserttest2", array("temp_id", "temp_id2", "temp_int", "temp_text"), array($strId, 2, 3, "row 3"), array("temp_id", "temp_id2"));
-        $objDB->insertOrUpdate("agp_temp_upserttest2", array("temp_id", "temp_id2", "temp_int", "temp_text"), array($strId, 3, 4, "row 4"), array("temp_id", "temp_id2"));
+        $this->assertCount(3, $objDB->getPArray('SELECT * FROM agp_temp_upserttest2', [], null, null, false));
 
+        $objDB->insertOrUpdate('agp_temp_upserttest2', ['temp_id', 'temp_id2', 'temp_int', 'temp_text'], [$strId, 3, 5, 'row 5'], ['temp_id', 'temp_id2']);
 
-        $this->assertEquals(count($objDB->getPArray("SELECT * FROM agp_temp_upserttest2", array(), null, null, false)), 3);
+        $this->assertCount(3, $objDB->getPArray('SELECT * FROM agp_temp_upserttest2', [], null, null, false));
 
-        $objDB->insertOrUpdate("agp_temp_upserttest2", array("temp_id", "temp_id2", "temp_int", "temp_text"), array($strId, 3, 5, "row 5"), array("temp_id", "temp_id2"));
+        $arrRow = $objDB->getPRow('SELECT * FROM agp_temp_upserttest2 WHERE temp_id = ? AND temp_id2 = ?', [$strId, 1]);
+        $this->assertEquals(2, $arrRow['temp_int']);
+        $this->assertEquals('row 2', $arrRow['temp_text']);
 
-        $this->assertEquals(count($objDB->getPArray("SELECT * FROM agp_temp_upserttest2", array(), null, null, false)), 3);
+        $arrRow = $objDB->getPRow('SELECT * FROM agp_temp_upserttest2 WHERE temp_id = ? AND temp_id2 = ?', array($strId, 2));
+        $this->assertEquals(3, $arrRow['temp_int']);
+        $this->assertEquals('row 3', $arrRow['temp_text']);
 
+        $arrRow = $objDB->getPRow('SELECT * FROM agp_temp_upserttest2 WHERE temp_id = ? AND temp_id2 = ?', array($strId, 3));
+        $this->assertEquals(5, $arrRow['temp_int']);
+        $this->assertEquals('row 5', $arrRow['temp_text']);
 
-        $arrRow = $objDB->getPRow("SELECT * FROM agp_temp_upserttest2 WHERE temp_id = ? AND temp_id2 = ?", array($strId, 1));
-        $this->assertEquals($arrRow["temp_int"], 2); $this->assertEquals($arrRow["temp_text"], "row 2");
-
-        $arrRow = $objDB->getPRow("SELECT * FROM agp_temp_upserttest2 WHERE temp_id = ? AND temp_id2 = ?", array($strId, 2));
-        $this->assertEquals($arrRow["temp_int"], 3); $this->assertEquals($arrRow["temp_text"], "row 3");
-
-        $arrRow = $objDB->getPRow("SELECT * FROM agp_temp_upserttest2 WHERE temp_id = ? AND temp_id2 = ?", array($strId, 3));
-        $this->assertEquals($arrRow["temp_int"], 5); $this->assertEquals($arrRow["temp_text"], "row 5");
-
-        $strQuery = "DROP TABLE agp_temp_upserttest2";
-        $this->assertTrue($objDB->_pQuery($strQuery, array()));
+        $strQuery = 'DROP TABLE agp_temp_upserttest2';
+        $this->assertTrue($objDB->_pQuery($strQuery));
     }
 
-
-    public function testUpsertPerformance()
+    /**
+     * @throws QueryException
+     * @throws ConnectionException
+     */
+    public function testUpsertPerformance(): void
     {
         $objDB = $this->getConnection();
-        if (in_array("agp_temp_upserttest3", $this->getConnection()->getTables())) {
-            $strQuery = "DROP TABLE agp_temp_upserttest3";
-            $this->getConnection()->_pQuery($strQuery, array());
+        if (in_array('agp_temp_upserttest3', $this->getConnection()->getTables(), true)) {
+            $strQuery = 'DROP TABLE agp_temp_upserttest3';
+            $this->getConnection()->_pQuery($strQuery);
         }
 
-        $arrFields = array();
-        $arrFields["temp_id"] = array("char20", false);
-        $arrFields["temp_id2"] = array("int", false);
-        $arrFields["temp_int"] = array("int", true);
-        $arrFields["temp_text"] = array("text", true);
+        $arrFields = [
+            'temp_id' => [DataType::CHAR20, false],
+            'temp_id2' => [DataType::INT, false],
+            'temp_int' => [DataType::INT, true],
+            'temp_text' => [DataType::TEXT, true],
+        ];
 
-        $this->assertTrue($objDB->createTable("agp_temp_upserttest3", $arrFields, array("temp_id", "temp_id2")));
-
+        $this->assertTrue($objDB->createTable('agp_temp_upserttest3', $arrFields, ['temp_id', 'temp_id2']));
 
         $strId1 = $this->generateSystemid();
         $strId2 = $this->generateSystemid();
         $strId3 = $this->generateSystemid();
 
-        $arrTestData = array(
-            array($strId1, 1, 1, "text 1"),
-            array($strId1, 1, 1, "text 1"),
-            array($strId1, 1, 1, "text 2"),
-            array($strId1, 2, 1, "text 1"),
-            array($strId1, 2, 3, "text 1"),
-            array($strId2, 1, 1, "text 1"),
-            array($strId2, 1, 1, "text 1"),
-            array($strId2, 1, 3, "text 1"),
-            array($strId1, 1, 3, "text 4"),
-            array($strId1, 1, 3, "text 5"),
-            array($strId3, 3, 3, "text 3"),
-            array($strId3, 3, 3, "text 4"),
-            array($strId3, 4, 3, "text 4"),
-            array($strId3, 4, 3, "text 4"),
-            array($strId3, 4, 5, "text 4"),
-        );
+        $arrTestData = [
+            [$strId1, 1, 1, 'text 1'],
+            [$strId1, 1, 1, 'text 1'],
+            [$strId1, 1, 1, 'text 2'],
+            [$strId1, 2, 1, 'text 1'],
+            [$strId1, 2, 3, 'text 1'],
+            [$strId2, 1, 1, 'text 1'],
+            [$strId2, 1, 1, 'text 1'],
+            [$strId2, 1, 3, 'text 1'],
+            [$strId1, 1, 3, 'text 4'],
+            [$strId1, 1, 3, 'text 5'],
+            [$strId3, 3, 3, 'text 3'],
+            [$strId3, 3, 3, 'text 4'],
+            [$strId3, 4, 3, 'text 4'],
+            [$strId3, 4, 3, 'text 4'],
+            [$strId3, 4, 5, 'text 4'],
+        ];
 
-
-        $intTime = -microtime(true);
         foreach($arrTestData as $arrOneRow) {
             $this->runInsertAndUpdate($arrOneRow[0], $arrOneRow[1], $arrOneRow[2], $arrOneRow[3]);
         }
-        $intTime += microtime(true);
-        //echo "runInsertAndUpdate: ".sprintf('%f', $intTime) ." sec".PHP_EOL;
 
-
-
-        $intTime2 = -microtime(true);
         foreach($arrTestData as $arrOneRow) {
             $this->runUpsert($arrOneRow[0], $arrOneRow[1], $arrOneRow[2], $arrOneRow[3]);
         }
-        $intTime2 += microtime(true);
-        //echo "runUpsert:          ".sprintf('%f', $intTime2) ." sec".PHP_EOL;
 
-
-        //Disbaled due to performance glitches on oracle
-        //$this->assertTrue($intTime2 < $intTime, "compare upsert performance");
-
-        $strQuery = "DROP TABLE agp_temp_upserttest3";
-        $this->assertTrue($objDB->_pQuery($strQuery, array()));
+        $strQuery = 'DROP TABLE agp_temp_upserttest3';
+        $this->assertTrue($objDB->_pQuery($strQuery));
     }
 
-    private function runUpsert($intId, $intId2, $intInt, $strText)
+    /**
+     * @throws QueryException
+     * @throws ConnectionException
+     */
+    private function runUpsert($intId, $intId2, $intInt, $strText): void
     {
-        $this->getConnection()->insertOrUpdate("agp_temp_upserttest3", array("temp_id", "temp_id2", "temp_int", "temp_text"), array($intId, $intId2, $intInt, $strText), array("temp_id", "temp_id2"));
+        $this->getConnection()->insertOrUpdate('agp_temp_upserttest3', ['temp_id', 'temp_id2', 'temp_int', 'temp_text'], [$intId, $intId2, $intInt, $strText], ['temp_id', 'temp_id2']);
     }
 
-    private function runInsertAndUpdate($intId, $intId2, $intInt, $strText)
+    /**
+     * @throws QueryException
+     * @throws ConnectionException
+     */
+    private function runInsertAndUpdate($intId, $intId2, $intInt, $strText): void
     {
         $objDb = $this->getConnection();
-        $arrRow = $objDb->getPRow("SELECT COUNT(*) AS cnt FROM agp_temp_upserttest3 WHERE temp_id = ? AND temp_id2 = ?", array($intId, $intId2), 0, false);
-        if($arrRow["cnt"] == "0") {
-            $strQuery = "INSERT INTO agp_temp_upserttest3 (temp_id, temp_id2, temp_int, temp_text) VALUES (?, ?, ?, ?)";
-            $objDb->_pQuery($strQuery, array($intId, $intId2, $intInt, $strText));
+        $arrRow = $objDb->getPRow('SELECT COUNT(*) AS cnt FROM agp_temp_upserttest3 WHERE temp_id = ? AND temp_id2 = ?', array($intId, $intId2), 0, false);
+        if($arrRow['cnt'] == '0') {
+            $strQuery = 'INSERT INTO agp_temp_upserttest3 (temp_id, temp_id2, temp_int, temp_text) VALUES (?, ?, ?, ?)';
+            $objDb->_pQuery($strQuery, [$intId, $intId2, $intInt, $strText]);
+        } else {
+            $strQuery = 'UPDATE agp_temp_upserttest3 SET temp_int = ?, temp_text = ? WHERE temp_id = ? AND temp_id2 = ?';
+            $objDb->_pQuery($strQuery, [$intInt, $strText, $intId, $intId2]);
         }
-        else {
-            $strQuery = "UPDATE agp_temp_upserttest3 SET temp_int = ?, temp_text = ? WHERE temp_id = ? AND temp_id2 = ?";
-            $objDb->_pQuery($strQuery, array($intInt, $strText, $intId, $intId2));
-        }
-
     }
 
     // this approach is not feasible! in an update matches a row with the same data, at least mysql returns 0.
     // where not matching: 0 affected, where matching but update not required: 0 affected
+    /**
+     * @throws ConnectionException
+     * @throws QueryException
+     */
     private function runInsertAndUpdateChangedRows($intId, $intId2, $intInt, $strText)
     {
         $objDb = $this->getConnection();
 
-        $strQuery = "UPDATE agp_temp_upserttest3 SET temp_int = ?, temp_text = ? WHERE temp_id = ? AND temp_id2 = ?";
-        $objDb->_pQuery($strQuery, array($intInt, $strText, $intId, $intId2));
-        if($objDb->getIntAffectedRows() == 0) {
-            $strQuery = "INSERT INTO agp_temp_upserttest3 (temp_id, temp_id2, temp_int, temp_text) VALUES (?, ?, ?, ?)";
-            $objDb->_pQuery($strQuery, array($intId, $intId2, $intInt, $strText));
+        $strQuery = 'UPDATE agp_temp_upserttest3 SET temp_int = ?, temp_text = ? WHERE temp_id = ? AND temp_id2 = ?';
+        $objDb->_pQuery($strQuery, [$intInt, $strText, $intId, $intId2]);
+        if($objDb->getAffectedRowsCount() == 0) {
+            $strQuery = 'INSERT INTO agp_temp_upserttest3 (temp_id, temp_id2, temp_int, temp_text) VALUES (?, ?, ?, ?)';
+            $objDb->_pQuery($strQuery, [$intId, $intId2, $intInt, $strText]);
         }
     }
-
 }
-

--- a/tests/Driver/MysqliDriverTest.php
+++ b/tests/Driver/MysqliDriverTest.php
@@ -7,9 +7,6 @@ namespace Artemeon\Database\Tests\Driver;
 use Artemeon\Database\Driver\MysqliDriver;
 use PHPUnit\Framework\TestCase;
 
-/**
- * @since 7.2
- */
 final class MysqliDriverTest extends TestCase
 {
     public function testBuildsDatabaseSpecificSubstringExpression(): void

--- a/tests/Driver/Oci8DriverTest.php
+++ b/tests/Driver/Oci8DriverTest.php
@@ -1,13 +1,12 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Artemeon\Database\Tests\Driver;
 
 use Artemeon\Database\Driver\Oci8Driver;
 use PHPUnit\Framework\TestCase;
 
-/**
- * @since 7.2
- */
 final class Oci8DriverTest extends TestCase
 {
     public function testBuildsDatabaseSpecificSubstringExpression(): void

--- a/tests/Driver/PostgresDriverTest.php
+++ b/tests/Driver/PostgresDriverTest.php
@@ -1,13 +1,12 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Artemeon\Database\Tests\Driver;
 
 use Artemeon\Database\Driver\PostgresDriver;
 use PHPUnit\Framework\TestCase;
 
-/**
- * @since 7.2
- */
 final class PostgresDriverTest extends TestCase
 {
     public function testBuildsDatabaseSpecificSubstringExpression(): void

--- a/tests/Driver/Sqlite3DriverTest.php
+++ b/tests/Driver/Sqlite3DriverTest.php
@@ -1,13 +1,12 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Artemeon\Database\Tests\Driver;
 
 use Artemeon\Database\Driver\Sqlite3Driver;
 use PHPUnit\Framework\TestCase;
 
-/**
- * @since 7.2
- */
 final class Sqlite3DriverTest extends TestCase
 {
     public function testBuildsDatabaseSpecificSubstringExpression(): void

--- a/tests/Driver/SqlsrvDriverTest.php
+++ b/tests/Driver/SqlsrvDriverTest.php
@@ -1,13 +1,12 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Artemeon\Database\Tests\Driver;
 
 use Artemeon\Database\Driver\SqlsrvDriver;
 use PHPUnit\Framework\TestCase;
 
-/**
- * @since 7.2
- */
 final class SqlsrvDriverTest extends TestCase
 {
     public function testBuildsDatabaseSpecificSubstringExpression(): void

--- a/tests/MockConnectionTest.php
+++ b/tests/MockConnectionTest.php
@@ -13,20 +13,23 @@ declare(strict_types=1);
 
 namespace Artemeon\Database\Tests;
 
+use Artemeon\Database\Exception\QueryException;
 use Artemeon\Database\MockConnection;
 
 class MockConnectionTest extends ConnectionTestCase
 {
-    public function testConnection()
+    /**
+     * @throws QueryException
+     */
+    public function testConnection(): void
     {
         $connection = new MockConnection();
         $connection->addRow(['title' => 'foo']);
         $connection->addRow(['title' => 'bar']);
 
-        $this->assertEquals([['title' => 'foo'], ['title' => 'bar']], $connection->getPArray('', []));
-        $this->assertEquals(['title' => 'foo'], $connection->getPRow('', []));
+        $this->assertEquals([['title' => 'foo'], ['title' => 'bar']], $connection->getPArray(''));
+        $this->assertEquals(['title' => 'foo'], $connection->getPRow(''));
         $this->assertEquals(['title' => 'foo'], $connection->selectRow('', [], []));
-        $this->assertEquals([['title' => 'foo'], ['title' => 'bar']], iterator_to_array($connection->getGenerator('', [])));
+        $this->assertEquals([['title' => 'foo'], ['title' => 'bar']], iterator_to_array($connection->getGenerator('')));
     }
 }
-

--- a/tests/Schema/TableTest.php
+++ b/tests/Schema/TableTest.php
@@ -11,17 +11,21 @@
 
 declare(strict_types=1);
 
-namespace Artemeon\Database\Schema\Tests;
+namespace Artemeon\Database\Tests\Schema;
 
 use Artemeon\Database\Schema\Table;
 use Artemeon\Database\Schema\TableColumn;
 use Artemeon\Database\Schema\TableIndex;
 use Artemeon\Database\Schema\TableKey;
+use JsonException;
 use PHPUnit\Framework\TestCase;
 
 class TableTest extends TestCase
 {
-    public function testTable()
+    /**
+     * @throws JsonException
+     */
+    public function testTable(): void
     {
         $table = new Table('foo');
         $table->addColumn(new TableColumn('bar'));
@@ -52,7 +56,7 @@ class TableTest extends TestCase
   ]
 }
 JSON;
-        $actual = json_encode($table);
+        $actual = json_encode($table, JSON_THROW_ON_ERROR);
         $this->assertJsonStringEqualsJsonString($expect, $actual, $actual);
     }
 }

--- a/tests/stubs.php
+++ b/tests/stubs.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 const OCI_COMMIT_ON_SUCCESS = 32;
 const OCI_NO_AUTO_COMMIT = 0;
 const SQLSRV_TXN_READ_UNCOMMITTED = 1;


### PR DESCRIPTION
# Description

- Bumps `symfony/process` to `^6.0.0`.
- Renames `ConnectionInterface::transactionBegin()` to `ConnectionInterface::beginTransaction()`.
- Renames `ConnectionInterface::transactionCommit()` to `ConnectionInterface::commitTransaction()`.
- Renames `ConnectionInterface::transactionRollback()` to `ConnectionInterface::rollbackTransaction()`.
- Renames `DriverInterface::transactionBegin()` to `DriverInterface::beginTransaction()`.
- Renames `DriverInterface::transactionCommit()` to `DriverInterface::commitTransaction()`.
- Renames `DriverInterface::transactionRollback()` to `DriverInterface::rollbackTransaction()`.
- Cleans up code