### PR TITLE
Query list including meta information

### DIFF
--- a/src/Connection.php
+++ b/src/Connection.php
@@ -1102,6 +1102,10 @@ class Connection implements ConnectionInterface
 
     private function addQueryToList(string $query, array $params, bool $cached, float $startTime): void
     {
+        if ($this->debugLevel !== 100) {
+            return;
+        }
+
         $this->queries[] = [
             'query' => $this->prettifyQuery($query, $params),
             'cached' => $cached,

--- a/src/Connection.php
+++ b/src/Connection.php
@@ -52,7 +52,7 @@ class Connection implements ConnectionInterface
      */
     private int $number = 0;
 
-    private  array $queries = [];
+    private array $queries = [];
 
     /**
      * Number of queries returned from cache.

--- a/src/ConnectionInterface.php
+++ b/src/ConnectionInterface.php
@@ -330,4 +330,29 @@ interface ConnectionInterface extends DoctrineConnectionInterface
      * the fitting length for the provided datatype.
      */
     public function convertToDatabaseValue(mixed $value, DataType $type): mixed;
+
+    /**
+     * Queries the current db-driver about common information.
+     */
+    public function getDbInfo(): array;
+
+    /**
+     * Returns an array of all queries.
+     */
+    public function getQueries(): array;
+
+    /**
+     * Returns the number of queries sent to the database including those solved by the cache.
+     */
+    public function getNumber(): int;
+
+    /**
+     * Returns the number of queries solved by the cache.
+     */
+    public function getNumberCache(): int;
+
+    /**
+     * Returns the number of items currently in the query-cache.
+     */
+    public function getCacheSize(): int;
 }

--- a/src/MockConnection.php
+++ b/src/MockConnection.php
@@ -325,4 +325,29 @@ class MockConnection implements ConnectionInterface
     {
         return (string) $value;
     }
+
+    public function getDbInfo(): array
+    {
+        return [];
+    }
+
+    public function getQueries(): array
+    {
+        return [];
+    }
+
+    public function getNumber(): int
+    {
+        return 0;
+    }
+
+    public function getNumberCache(): int
+    {
+        return 0;
+    }
+
+    public function getCacheSize(): int
+    {
+        return 0;
+    }
 }


### PR DESCRIPTION
Pushes all queries to an array with some meta information like execution time and if the query was resolved from cache or not.

The queries can be returned by `->getQueries()` (just like `->getNumber()` to get the number of executed queries).