### PR TITLE
feat: Add `dbExport` and `dbImport` to `ConnectionInterface`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 3.2.2
+
+- Adds the `dbExport` and `dbImport` methods to the `ConnectionInterface`.
+
 ## 3.2.1
 
 - Automatically convert backend enums to the value so that a user can provide an enum class as parameter

--- a/src/Connection.php
+++ b/src/Connection.php
@@ -1394,4 +1394,14 @@ class Connection implements ConnectionInterface
     {
         return $this->dbDriver->getStringLengthExpression($targetString);
     }
+
+    public function dbExport(string &$fileName, array $tables): bool
+    {
+        return $this->dbDriver->dbExport($fileName, $tables);
+    }
+
+    public function dbImport(string $fileName): bool
+    {
+        return $this->dbDriver->dbImport($fileName);
+    }
 }

--- a/src/ConnectionInterface.php
+++ b/src/ConnectionInterface.php
@@ -355,4 +355,17 @@ interface ConnectionInterface extends DoctrineConnectionInterface
      * Returns the number of items currently in the query-cache.
      */
     public function getCacheSize(): int;
+
+    /**
+     * Creates an db-dump using the given filename. The filename is relative to _realpath_
+     * The dump must include, and ONLY include the pass tables.
+     *
+     * @param string &$fileName passed by reference so that the driver is able to update the filename, e.g. in order to add a .gz suffix.
+     */
+    public function dbExport(string &$fileName, array $tables): bool;
+
+    /**
+     * Imports the given db-dump file to the database. The filename ist relative to _realpath_.
+     */
+    public function dbImport(string $fileName): bool;
 }

--- a/src/MockConnection.php
+++ b/src/MockConnection.php
@@ -350,4 +350,14 @@ class MockConnection implements ConnectionInterface
     {
         return 0;
     }
+
+    public function dbExport(string &$fileName, array $tables): bool
+    {
+        return false;
+    }
+
+    public function dbImport(string $fileName): bool
+    {
+        return false;
+    }
 }


### PR DESCRIPTION
Adds the missing `dbExport` and `dbImport` methods to the connection interface.