### PR TITLE
chore: Decouple driver dump/restore tests from filesystem

### DIFF
--- a/src/Driver/DriverAbstract.php
+++ b/src/Driver/DriverAbstract.php
@@ -20,6 +20,7 @@ use Artemeon\Database\Exception\QueryException;
 use Artemeon\Database\Schema\DataType;
 use Artemeon\Database\Schema\TableIndex;
 use Override;
+use Symfony\Component\Process\ExecutableFinder;
 use Symfony\Component\Process\Process;
 
 /**
@@ -364,5 +365,21 @@ abstract class DriverAbstract implements DriverInterface
         }
 
         return true;
+    }
+
+    /**
+     * Resolves an executable on $PATH.
+     *
+     * @throws \RuntimeException if the binary is not found
+     */
+    protected function findExecutable(string $name): string
+    {
+        $path = new ExecutableFinder()->find($name);
+
+        if ($path === null) {
+            throw new \RuntimeException("Executable '{$name}' not found in PATH");
+        }
+
+        return $path;
     }
 }

--- a/src/Driver/MysqliDriver.php
+++ b/src/Driver/MysqliDriver.php
@@ -28,7 +28,6 @@ use mysqli_sql_exception;
 use mysqli_stmt;
 use Override;
 use RuntimeException;
-use Symfony\Component\Process\ExecutableFinder;
 use Symfony\Component\Process\Process;
 
 /**
@@ -565,7 +564,7 @@ class MysqliDriver extends DriverAbstract
             throw new RuntimeException('Connection parameters not set');
         }
 
-        $dumpBin = new ExecutableFinder()->find($this->dumpBin);
+        $dumpBin = $this->findExecutable($this->dumpBin);
         $dumpParams = [
             $dumpBin,
             '-h', escapeshellarg($this->config->getHost()),
@@ -608,7 +607,7 @@ class MysqliDriver extends DriverAbstract
             throw new RuntimeException('Connection parameters not set');
         }
 
-        $restoreBin = new ExecutableFinder()->find($this->restoreBin);
+        $restoreBin = $this->findExecutable($this->restoreBin);
 
         $restoreParams = [
             $restoreBin,

--- a/src/Driver/PostgresDriver.php
+++ b/src/Driver/PostgresDriver.php
@@ -25,7 +25,6 @@ use Generator;
 use Override;
 use PgSql\Connection;
 use RuntimeException;
-use Symfony\Component\Process\ExecutableFinder;
 use Symfony\Component\Process\Process;
 
 /**
@@ -525,7 +524,7 @@ class PostgresDriver extends DriverAbstract
             $port = 5432;
         }
 
-        $dumpBin = new ExecutableFinder()->find($this->dumpBin);
+        $dumpBin = $this->findExecutable($this->dumpBin);
         $dumpParams = [
             $dumpBin,
             '--clean',
@@ -571,7 +570,7 @@ class PostgresDriver extends DriverAbstract
             throw new RuntimeException('Connection parameters not set');
         }
 
-        $restoreBin = new ExecutableFinder()->find($this->restoreBin);
+        $restoreBin = $this->findExecutable($this->restoreBin);
         if ($this->handlesDumpCompression() && pathinfo($fileName, PATHINFO_EXTENSION) === 'gz') {
             $restoreParams = [
                 $restoreBin,

--- a/tests/Driver/MysqliDriverTest.php
+++ b/tests/Driver/MysqliDriverTest.php
@@ -65,6 +65,12 @@ final class MysqliDriverTest extends TestCase
             ->makePartial();
 
         $dbServiceMock->shouldAllowMockingProtectedMethods()
+            ->shouldReceive('findExecutable')
+            ->once()
+            ->with('mysqldump')
+            ->andReturn('/usr/bin/mysqldump');
+
+        $dbServiceMock->shouldAllowMockingProtectedMethods()
             ->shouldReceive('runProcess')
             ->once()
             ->withArgs(static function (Process $process) use ($expectedCommandLine): bool {
@@ -127,6 +133,12 @@ final class MysqliDriverTest extends TestCase
         $dbServiceMock->shouldReceive('handlesDumpCompression')
             ->once()
             ->andReturn(true);
+
+        $dbServiceMock->shouldAllowMockingProtectedMethods()
+            ->shouldReceive('findExecutable')
+            ->once()
+            ->with('mysql')
+            ->andReturn('/usr/bin/mysql');
 
         $dbServiceMock->shouldAllowMockingProtectedMethods()
             ->shouldReceive('runProcess')

--- a/tests/Driver/PostgresDriverTest.php
+++ b/tests/Driver/PostgresDriverTest.php
@@ -69,6 +69,12 @@ final class PostgresDriverTest extends TestCase
             ->andReturn(true);
 
         $dbServiceMock->shouldAllowMockingProtectedMethods()
+            ->shouldReceive('findExecutable')
+            ->once()
+            ->with('pg_dump')
+            ->andReturn('/usr/bin/pg_dump');
+
+        $dbServiceMock->shouldAllowMockingProtectedMethods()
             ->shouldReceive('runProcess')
             ->once()
             ->withArgs(function (Process $process) use ($expectedCommandLine): bool {
@@ -131,6 +137,12 @@ final class PostgresDriverTest extends TestCase
         $dbServiceMock->shouldReceive('handlesDumpCompression')
             ->once()
             ->andReturn(true);
+
+        $dbServiceMock->shouldAllowMockingProtectedMethods()
+            ->shouldReceive('findExecutable')
+            ->once()
+            ->with('psql')
+            ->andReturn('/usr/bin/psql');
 
         $dbServiceMock->shouldAllowMockingProtectedMethods()
             ->shouldReceive('runProcess')


### PR DESCRIPTION
Closes #91.

Moves binary lookup (`mysqldump`, `mysql`, `pg_dump`, `psql`) from inline `new ExecutableFinder()->find(...)` calls into a protected `DriverAbstract::findExecutable()` so the dump/restore tests can stub it like every other dependency. Without this, the tests under `tests/Driver/{MysqliDriver,PostgresDriver}Test.php` are nominally unit tests but in practice require those binaries to exist on `PATH` — which fails in clean environments such as `gh act` runner images.

The new helper throws `RuntimeException` on miss to replace the silent `null` that previously propagated into `Process`, surfacing missing-binary errors with a clear message at the right point.