### PR TITLE
feat: Add TINYINT and SMALLINT data types

### DIFF
--- a/src/Connection.php
+++ b/src/Connection.php
@@ -865,6 +865,15 @@ class Connection implements ConnectionInterface
 
     /**
      * @inheritDoc
+     */
+    #[Override]
+    public function mapsToSameDatatype(DataType $a, DataType $b): bool
+    {
+        return $this->getDatatype($a) === $this->getDatatype($b);
+    }
+
+    /**
+     * @inheritDoc
      * @throws ConnectionException
      */
     #[Override]

--- a/src/ConnectionInterface.php
+++ b/src/ConnectionInterface.php
@@ -194,6 +194,17 @@ interface ConnectionInterface extends DoctrineConnectionInterface
     public function getDatatype(DataType $type): string;
 
     /**
+     * Returns true when both datatypes resolve to the same backend SQL via
+     * {@see self::getDatatype()}.
+     *
+     * Useful for schema-drift checks: e.g. on Postgres, TINYINT and SMALLINT
+     * both map to "SMALLINT", and on SQLite all integer types collapse to
+     * "INTEGER". A naive enum comparison would falsely report drift after a
+     * round-trip through such a backend.
+     */
+    public function mapsToSameDatatype(DataType $a, DataType $b): bool;
+
+    /**
      * Used to send a `CREATE TABLE` statement to the database.
      * By passing the query through this method, the driver can add db-specific commands.
      *

--- a/src/Driver/MysqliDriver.php
+++ b/src/Driver/MysqliDriver.php
@@ -320,6 +320,14 @@ class MysqliDriver extends DriverAbstract
      */
     private function getCoreTypeForDbType(array $infoSchemaRow): ?DataType
     {
+        if ($infoSchemaRow['Type'] === 'tinyint(4)' || $infoSchemaRow['Type'] === 'tinyint') {
+            return DataType::TINYINT;
+        }
+
+        if ($infoSchemaRow['Type'] === 'smallint(6)' || $infoSchemaRow['Type'] === 'smallint') {
+            return DataType::SMALLINT;
+        }
+
         if ($infoSchemaRow['Type'] === 'int(11)' || $infoSchemaRow['Type'] === 'int') {
             return DataType::INT;
         }
@@ -374,6 +382,8 @@ class MysqliDriver extends DriverAbstract
     public function getDatatype(DataType $type): string
     {
         return match ($type) {
+            DataType::TINYINT => ' TINYINT ',
+            DataType::SMALLINT => ' SMALLINT ',
             DataType::INT => ' INT ',
             DataType::BIGINT => ' BIGINT ',
             DataType::FLOAT => ' DOUBLE ',

--- a/src/Driver/PostgresDriver.php
+++ b/src/Driver/PostgresDriver.php
@@ -295,6 +295,10 @@ class PostgresDriver extends DriverAbstract
      */
     private function getCoreTypeForDbType(array $infoSchemaRow): ?DataType
     {
+        if ($infoSchemaRow['data_type'] === 'smallint') {
+            return DataType::SMALLINT;
+        }
+
         if ($infoSchemaRow['data_type'] === 'integer') {
             return DataType::INT;
         }
@@ -341,6 +345,7 @@ class PostgresDriver extends DriverAbstract
     public function getDatatype(DataType $type): string
     {
         return match ($type) {
+            DataType::TINYINT, DataType::SMALLINT => ' SMALLINT ',
             DataType::INT => ' INT ',
             DataType::BIGINT => ' BIGINT ',
             DataType::FLOAT => ' NUMERIC ',

--- a/src/Driver/Sqlite3Driver.php
+++ b/src/Driver/Sqlite3Driver.php
@@ -610,7 +610,7 @@ class Sqlite3Driver extends DriverAbstract
     public function getDatatype(DataType $type): string
     {
         return match ($type) {
-            DataType::INT, DataType::BIGINT => ' INTEGER ',
+            DataType::TINYINT, DataType::SMALLINT, DataType::INT, DataType::BIGINT => ' INTEGER ',
             DataType::FLOAT => ' REAL ',
             default => ' TEXT ',
         };

--- a/src/MockConnection.php
+++ b/src/MockConnection.php
@@ -245,6 +245,12 @@ class MockConnection implements ConnectionInterface
     }
 
     #[Override]
+    public function mapsToSameDatatype(DataType $a, DataType $b): bool
+    {
+        return $this->getDatatype($a) === $this->getDatatype($b);
+    }
+
+    #[Override]
     public function createTable(string $tableName, array $columns, array $keys, array $indices = []): bool
     {
         return true;

--- a/src/Schema/DataType.php
+++ b/src/Schema/DataType.php
@@ -18,6 +18,8 @@ namespace Artemeon\Database\Schema;
  */
 enum DataType: string
 {
+    case TINYINT = 'tinyint';
+    case SMALLINT = 'smallint';
     case INT = 'int';
     case BIGINT = 'long';
     case FLOAT = 'double';

--- a/tests/ConnectionColumnTypeTest.php
+++ b/tests/ConnectionColumnTypeTest.php
@@ -17,6 +17,7 @@ use Artemeon\Database\Exception\ConnectionException;
 use Artemeon\Database\Exception\QueryException;
 use Artemeon\Database\Exception\TableNotFoundException;
 use Artemeon\Database\Schema\DataType;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 /**
  * @internal
@@ -45,14 +46,22 @@ class ConnectionColumnTypeTest extends ConnectionTestCase
         }
     }
 
-    public function testMapsToSameDatatype(): void
+    /**
+     * @return iterable<string, array{DataType, DataType, bool}>
+     */
+    public static function provideMapsToSameDatatypeCases(): iterable
     {
-        $connection = $this->getConnection();
+        yield 'INT == INT' => [DataType::INT, DataType::INT, true];
+        yield 'TEXT == TEXT' => [DataType::TEXT, DataType::TEXT, true];
+        yield 'INT vs TEXT must stay distinct on every backend' => [DataType::INT, DataType::TEXT, false];
+    }
 
-        $this->assertTrue($connection->mapsToSameDatatype(DataType::INT, DataType::INT));
-        $this->assertTrue($connection->mapsToSameDatatype(DataType::TEXT, DataType::TEXT));
-
-        // distinct types must not collapse on any backend
-        $this->assertFalse($connection->mapsToSameDatatype(DataType::INT, DataType::TEXT));
+    #[DataProvider('provideMapsToSameDatatypeCases')]
+    public function testMapsToSameDatatype(DataType $a, DataType $b, bool $expected): void
+    {
+        $this->assertSame(
+            $expected,
+            $this->getConnection()->mapsToSameDatatype($a, $b),
+        );
     }
 }

--- a/tests/ConnectionColumnTypeTest.php
+++ b/tests/ConnectionColumnTypeTest.php
@@ -16,6 +16,7 @@ namespace Artemeon\Database\Tests;
 use Artemeon\Database\Exception\ConnectionException;
 use Artemeon\Database\Exception\QueryException;
 use Artemeon\Database\Exception\TableNotFoundException;
+use Artemeon\Database\Schema\DataType;
 
 /**
  * @internal
@@ -42,5 +43,16 @@ class ConnectionColumnTypeTest extends ConnectionTestCase
                 $this->getConnection()->getDatatype($details['columnType']),
             );
         }
+    }
+
+    public function testMapsToSameDatatype(): void
+    {
+        $connection = $this->getConnection();
+
+        $this->assertTrue($connection->mapsToSameDatatype(DataType::INT, DataType::INT));
+        $this->assertTrue($connection->mapsToSameDatatype(DataType::TEXT, DataType::TEXT));
+
+        // distinct types must not collapse on any backend
+        $this->assertFalse($connection->mapsToSameDatatype(DataType::INT, DataType::TEXT));
     }
 }

--- a/tests/ConnectionMultiInsertTest.php
+++ b/tests/ConnectionMultiInsertTest.php
@@ -52,6 +52,8 @@ class ConnectionMultiInsertTest extends ConnectionTestCase
         for ($i = 1; $i <= 50; $i++) {
             $row = $connection->getPRow('SELECT * FROM ' . self::TEST_TABLE_NAME . ' WHERE temp_int = ?', [123456 + $i]);
 
+            $this->assertEquals($i % 128, $row['temp_tinyint']);
+            $this->assertEquals(1000 + $i, $row['temp_smallint']);
             $this->assertEquals(123456 + $i, $row['temp_int']);
             $this->assertEquals(20200508095300 + $i, $row['temp_bigint']);
             $this->assertIsScalar($row['temp_float']);

--- a/tests/ConnectionTestCase.php
+++ b/tests/ConnectionTestCase.php
@@ -92,6 +92,8 @@ abstract class ConnectionTestCase extends TestCase
     {
         return [
             'temp_id' => [DataType::CHAR20, false],
+            'temp_tinyint' => [DataType::TINYINT, true],
+            'temp_smallint' => [DataType::SMALLINT, true],
             'temp_int' => [DataType::INT, true],
             'temp_bigint' => [DataType::BIGINT, true],
             'temp_float' => [DataType::FLOAT, true],
@@ -119,6 +121,8 @@ abstract class ConnectionTestCase extends TestCase
         for ($i = 1; $i <= $count; $i++) {
             $row = [
                 'temp_id' => $this->generateSystemid(),
+                'temp_tinyint' => $i % 128,
+                'temp_smallint' => 1000 + $i,
                 'temp_int' => 123456 + $i,
                 'temp_bigint' => 20200508095300 + $i,
                 'temp_float' => 23.45,
@@ -144,6 +148,8 @@ abstract class ConnectionTestCase extends TestCase
     {
         return [
             'temp_id',
+            'temp_tinyint',
+            'temp_smallint',
             'temp_int',
             'temp_bigint',
             'temp_float',

--- a/tests/Driver/MysqliDriverTest.php
+++ b/tests/Driver/MysqliDriverTest.php
@@ -6,6 +6,7 @@ namespace Artemeon\Database\Tests\Driver;
 
 use Artemeon\Database\ConnectionParameters;
 use Artemeon\Database\Driver\MysqliDriver;
+use Artemeon\Database\Schema\DataType;
 use Mockery;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
@@ -24,6 +25,16 @@ final class MysqliDriverTest extends TestCase
         self::assertEquals('SUBSTRING(test_column, 1, 1)', $mysqliDriver->getSubstringExpression('test_column', 1, 1));
         self::assertEquals('SUBSTRING("test value", 1)', $mysqliDriver->getSubstringExpression('"test value"', 1, null));
         self::assertEquals('SUBSTRING("test value", 1, 1)', $mysqliDriver->getSubstringExpression('"test value"', 1, 1));
+    }
+
+    public function testKeepsIntegerTypesDistinct(): void
+    {
+        $driver = new MysqliDriver();
+
+        self::assertSame(' TINYINT ', $driver->getDatatype(DataType::TINYINT));
+        self::assertSame(' SMALLINT ', $driver->getDatatype(DataType::SMALLINT));
+        self::assertSame(' INT ', $driver->getDatatype(DataType::INT));
+        self::assertSame(' BIGINT ', $driver->getDatatype(DataType::BIGINT));
     }
 
     /**

--- a/tests/Driver/PostgresDriverTest.php
+++ b/tests/Driver/PostgresDriverTest.php
@@ -6,6 +6,7 @@ namespace Artemeon\Database\Tests\Driver;
 
 use Artemeon\Database\ConnectionParameters;
 use Artemeon\Database\Driver\PostgresDriver;
+use Artemeon\Database\Schema\DataType;
 use Mockery;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
@@ -24,6 +25,17 @@ final class PostgresDriverTest extends TestCase
         self::assertEquals('SUBSTRING(cast (test_column as text), 1, 1)', $postgresDriver->getSubstringExpression('test_column', 1, 1));
         self::assertEquals('SUBSTRING(cast ("test value" as text), 1)', $postgresDriver->getSubstringExpression('"test value"', 1, null));
         self::assertEquals('SUBSTRING(cast ("test value" as text), 1, 1)', $postgresDriver->getSubstringExpression('"test value"', 1, 1));
+    }
+
+    public function testCollapsesTinyintToSmallint(): void
+    {
+        $driver = new PostgresDriver();
+
+        // Postgres has no 1-byte integer type, so TINYINT round-trips as SMALLINT.
+        self::assertSame(' SMALLINT ', $driver->getDatatype(DataType::TINYINT));
+        self::assertSame(' SMALLINT ', $driver->getDatatype(DataType::SMALLINT));
+        self::assertSame(' INT ', $driver->getDatatype(DataType::INT));
+        self::assertSame(' BIGINT ', $driver->getDatatype(DataType::BIGINT));
     }
 
     /**

--- a/tests/Driver/Sqlite3DriverTest.php
+++ b/tests/Driver/Sqlite3DriverTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Artemeon\Database\Tests\Driver;
 
 use Artemeon\Database\Driver\Sqlite3Driver;
+use Artemeon\Database\Schema\DataType;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -20,5 +21,15 @@ final class Sqlite3DriverTest extends TestCase
         self::assertEquals('SUBSTR(test_column, 1, 1)', $sqlite3Driver->getSubstringExpression('test_column', 1, 1));
         self::assertEquals('SUBSTR("test value", 1)', $sqlite3Driver->getSubstringExpression('"test value"', 1, null));
         self::assertEquals('SUBSTR("test value", 1, 1)', $sqlite3Driver->getSubstringExpression('"test value"', 1, 1));
+    }
+
+    public function testCollapsesAllIntegerTypesToInteger(): void
+    {
+        $driver = new Sqlite3Driver();
+
+        self::assertSame(' INTEGER ', $driver->getDatatype(DataType::TINYINT));
+        self::assertSame(' INTEGER ', $driver->getDatatype(DataType::SMALLINT));
+        self::assertSame(' INTEGER ', $driver->getDatatype(DataType::INT));
+        self::assertSame(' INTEGER ', $driver->getDatatype(DataType::BIGINT));
     }
 }


### PR DESCRIPTION
Closes #93.

Adds `DataType::TINYINT` and `DataType::SMALLINT` with the expected per-driver mappings:

- **MySQL:** native `TINYINT` / `SMALLINT`; recognize both `tinyint(4)`/`tinyint` and `smallint(6)`/`smallint` on read.
- **Postgres:** both collapse to `SMALLINT` (no 1-byte int).
- **SQLite:** both collapse to `INTEGER` like the other int types.

### `Connection::mapsToSameDatatype()`

Postgres and SQLite collapse multiple `DataType` cases to the same backend SQL — on Postgres TINYINT/SMALLINT both map to `SMALLINT`, and on SQLite all integer types map to `INTEGER` (plus all `CHAR*` / `LONGTEXT` to `TEXT`). Consumers that compare a declared `DataType` against the type read back via `getColumnsOfTable()` / `getInternalType()` using enum identity see false-positive drift on those backends.

To make the new types safely usable, `Connection::mapsToSameDatatype(DataType $a, DataType $b): bool` is exposed. It returns `true` when both cases produce the same `getDatatype()` SQL.

> **Consumers performing schema-drift checks must switch from enum equality to this helper.** This was already latently true on SQLite for `BIGINT`, `CHAR*` and `LONGTEXT`; adding `TINYINT` extends it to Postgres.