### PR TITLE
test: add dbsafeString coverage

### DIFF
--- a/tests/ConnectionTest.php
+++ b/tests/ConnectionTest.php
@@ -1043,6 +1043,16 @@ class ConnectionTest extends ConnectionTestCase
                 'input' => StringBackedEnum::WithQuote,
                 'expected' => "O\\'Brien",
             ],
+            'BackedEnum (htmlSpecialChars=false skips html escape)' => [
+                'input' => StringBackedEnum::WithHtml,
+                'expected' => '<a>',
+                'htmlSpecialChars' => false,
+            ],
+            'BackedEnum (addSlashes=false skips slash escape)' => [
+                'input' => StringBackedEnum::WithQuote,
+                'expected' => "O'Brien",
+                'addSlashes' => false,
+            ],
             'EscapeableParameterInterface (string)' => [
                 'input' => new EscapeableValue('hello'),
                 'expected' => 'hello',
@@ -1062,6 +1072,16 @@ class ConnectionTest extends ConnectionTestCase
             'EscapeableParameterInterface (string with quote is escaped)' => [
                 'input' => new EscapeableValue("O'Brien"),
                 'expected' => "O\\'Brien",
+            ],
+            'EscapeableParameterInterface (htmlSpecialChars=false skips html escape)' => [
+                'input' => new EscapeableValue('<a>'),
+                'expected' => '<a>',
+                'htmlSpecialChars' => false,
+            ],
+            'EscapeableParameterInterface (addSlashes=false skips slash escape)' => [
+                'input' => new EscapeableValue("O'Brien"),
+                'expected' => "O'Brien",
+                'addSlashes' => false,
             ],
         ];
     }

--- a/tests/ConnectionTest.php
+++ b/tests/ConnectionTest.php
@@ -20,6 +20,9 @@ use Artemeon\Database\Exception\ConnectionException;
 use Artemeon\Database\Exception\QueryException;
 use Artemeon\Database\Exception\RemoveColumnException;
 use Artemeon\Database\Schema\DataType;
+use Artemeon\Database\Tests\Fixtures\EscapeableValue;
+use Artemeon\Database\Tests\Fixtures\IntBackedEnum;
+use Artemeon\Database\Tests\Fixtures\StringBackedEnum;
 use DateInterval;
 use DateTime;
 use PHPUnit\Framework\Attributes\CoversClass;
@@ -961,5 +964,105 @@ class ConnectionTest extends ConnectionTestCase
         $connection = $this->getConnection();
         $this->assertTrue($connection->hasTable($tableName));
         $this->assertFalse($connection->hasTable('table_does_not_exist'));
+    }
+
+    #[DataProvider('dbsafeStringProvider')]
+    public function testDbsafeString(
+        mixed $input,
+        mixed $expected,
+        bool $htmlSpecialChars = true,
+        bool $addSlashes = true,
+    ): void {
+        $this->assertSame(
+            $expected,
+            $this->getConnection()->dbsafeString($input, $htmlSpecialChars, $addSlashes),
+        );
+    }
+
+    /**
+     * @return array<string, array{input: mixed, expected: mixed, htmlSpecialChars?: bool, addSlashes?: bool}>
+     */
+    public static function dbsafeStringProvider(): array
+    {
+        return [
+            'null' => [
+                'input' => null,
+                'expected' => null,
+            ],
+            'int' => [
+                'input' => 42,
+                'expected' => 42,
+            ],
+            'float' => [
+                'input' => 1.5,
+                'expected' => 1.5,
+            ],
+            'bool true is cast to 1' => [
+                'input' => true,
+                'expected' => 1,
+            ],
+            'bool false is cast to 0' => [
+                'input' => false,
+                'expected' => 0,
+            ],
+            'plain string passthrough' => [
+                'input' => 'plain',
+                'expected' => 'plain',
+            ],
+            'string with html chars is escaped' => [
+                'input' => '<a>',
+                'expected' => '&lt;a&gt;',
+            ],
+            'string with quote is escaped' => [
+                'input' => "O'Brien",
+                'expected' => "O\\'Brien",
+            ],
+            'htmlSpecialChars=false skips html escape' => [
+                'input' => '<a>',
+                'expected' => '<a>',
+                'htmlSpecialChars' => false,
+            ],
+            'addSlashes=false skips slash escape' => [
+                'input' => "O'Brien",
+                'expected' => "O'Brien",
+                'addSlashes' => false,
+            ],
+            'BackedEnum (string)' => [
+                'input' => StringBackedEnum::Foo,
+                'expected' => 'foo',
+            ],
+            'BackedEnum (int)' => [
+                'input' => IntBackedEnum::Forty,
+                'expected' => 40,
+            ],
+            'BackedEnum (string with html chars is escaped)' => [
+                'input' => StringBackedEnum::WithHtml,
+                'expected' => '&lt;a&gt;',
+            ],
+            'BackedEnum (string with quote is escaped)' => [
+                'input' => StringBackedEnum::WithQuote,
+                'expected' => "O\\'Brien",
+            ],
+            'EscapeableParameterInterface (string)' => [
+                'input' => new EscapeableValue('hello'),
+                'expected' => 'hello',
+            ],
+            'EscapeableParameterInterface (int)' => [
+                'input' => new EscapeableValue(123),
+                'expected' => 123,
+            ],
+            'EscapeableParameterInterface (null)' => [
+                'input' => new EscapeableValue(null),
+                'expected' => null,
+            ],
+            'EscapeableParameterInterface (string with html chars is escaped)' => [
+                'input' => new EscapeableValue('<a>'),
+                'expected' => '&lt;a&gt;',
+            ],
+            'EscapeableParameterInterface (string with quote is escaped)' => [
+                'input' => new EscapeableValue("O'Brien"),
+                'expected' => "O\\'Brien",
+            ],
+        ];
     }
 }

--- a/tests/Fixtures/EscapeableValue.php
+++ b/tests/Fixtures/EscapeableValue.php
@@ -1,0 +1,37 @@
+<?php
+
+/*
+ * This file is part of the Artemeon Core - Web Application Framework.
+ *
+ * (c) Artemeon <www.artemeon.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Artemeon\Database\Tests\Fixtures;
+
+use Artemeon\Database\EscapeableParameterInterface;
+use Stringable;
+
+final class EscapeableValue implements EscapeableParameterInterface
+{
+    /**
+     * @param scalar|Stringable|null $value
+     */
+    public function __construct(private readonly mixed $value)
+    {
+    }
+
+    public function isEscape(): bool
+    {
+        return true;
+    }
+
+    public function getValue(): mixed
+    {
+        return $this->value;
+    }
+}

--- a/tests/Fixtures/IntBackedEnum.php
+++ b/tests/Fixtures/IntBackedEnum.php
@@ -1,0 +1,19 @@
+<?php
+
+/*
+ * This file is part of the Artemeon Core - Web Application Framework.
+ *
+ * (c) Artemeon <www.artemeon.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Artemeon\Database\Tests\Fixtures;
+
+enum IntBackedEnum: int
+{
+    case Forty = 40;
+}

--- a/tests/Fixtures/StringBackedEnum.php
+++ b/tests/Fixtures/StringBackedEnum.php
@@ -1,0 +1,21 @@
+<?php
+
+/*
+ * This file is part of the Artemeon Core - Web Application Framework.
+ *
+ * (c) Artemeon <www.artemeon.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Artemeon\Database\Tests\Fixtures;
+
+enum StringBackedEnum: string
+{
+    case Foo = 'foo';
+    case WithHtml = '<a>';
+    case WithQuote = "O'Brien";
+}


### PR DESCRIPTION
## Summary
- Adds `testDbsafeString` to `ConnectionTest` with 19 table-driven cases.
- Covers existing behavior (null, int, float, bool, plain string, htmlspecialchars, addslashes, flag toggles) and the new unwrap branches from #96 (`BackedEnum`, `EscapeableParameterInterface`).
- Each unwrap branch is exercised against passthrough + htmlspecialchars + addslashes independently (no white-box reliance on the post-unwrap path).
- New fixtures: `tests/Fixtures/StringBackedEnum.php`, `IntBackedEnum.php`, `EscapeableValue.php`.

Base branch is #96 (`fix/phpstan`); merge that first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)